### PR TITLE
Feature/interactive lyrics and UI enhancements

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,7 +12,7 @@ import { UserProfile } from './components/UserProfile';
 import { SettingsModal } from './components/SettingsModal';
 import { SongProfile } from './components/SongProfile';
 import { Song, GenerationParams, View, Playlist } from './types';
-import { generateApi, songsApi, playlistsApi, getAudioUrl } from './services/api';
+import { generateApi, songsApi, playlistsApi, getAudioUrl, UserProfile as UserProfileType } from './services/api';
 import { useAuth } from './context/AuthContext';
 import { useResponsive } from './context/ResponsiveContext';
 import { I18nProvider, useI18n } from './context/I18nContext';
@@ -97,9 +97,12 @@ function AppContent() {
 
   // Profile View
   const [viewingUsername, setViewingUsername] = useState<string | null>(null);
+  const [viewingProfilePreview, setViewingProfilePreview] = useState<UserProfileType | null>(null);
+  const [profileReturnView, setProfileReturnView] = useState<View>('create');
 
   // Song View
   const [viewingSongId, setViewingSongId] = useState<string | null>(null);
+  const [viewingSongPreview, setViewingSongPreview] = useState<Song | null>(null);
 
   // Playlist View
   const [viewingPlaylistId, setViewingPlaylistId] = useState<string | null>(null);
@@ -206,6 +209,22 @@ function AppContent() {
 
   // Navigate to Profile Handler
   const handleNavigateToProfile = (username: string) => {
+    const previewSource =
+      currentSong?.creator === username ? currentSong :
+      selectedSong?.creator === username ? selectedSong :
+      songs.find(song => song.creator === username) || null;
+    const fallbackId = user?.username === username ? user.id : previewSource?.userId || username;
+    setViewingProfilePreview({
+      id: fallbackId,
+      username,
+      avatar_url: user?.username === username ? user.avatar_url : previewSource?.creator_avatar,
+      banner_url: user?.username === username ? user.banner_url : undefined,
+      bio: user?.username === username ? user.bio : undefined,
+      created_at: user?.createdAt || new Date().toISOString(),
+    });
+    if (currentView !== 'profile') {
+      setProfileReturnView(currentView);
+    }
     setViewingUsername(username);
     setCurrentView('profile');
     window.history.pushState({}, '', `/@${username}`);
@@ -214,12 +233,26 @@ function AppContent() {
   // Back from Profile Handler
   const handleBackFromProfile = () => {
     setViewingUsername(null);
-    setCurrentView('create');
-    window.history.pushState({}, '', '/');
+    setViewingProfilePreview(null);
+    setCurrentView(profileReturnView);
+    const returnPath =
+      profileReturnView === 'search' ? '/search' :
+      profileReturnView === 'library' ? '/library' :
+      profileReturnView === 'song' && viewingSongId ? `/song/${viewingSongId}` :
+      profileReturnView === 'playlist' && viewingPlaylistId ? `/playlist/${viewingPlaylistId}` :
+      profileReturnView === 'training' ? '/training' :
+      profileReturnView === 'news' ? '/news' :
+      '/';
+    window.history.pushState({}, '', returnPath);
   };
 
   // Navigate to Song Handler
   const handleNavigateToSong = (songId: string) => {
+    const previewSong =
+      currentSong?.id === songId ? currentSong :
+      selectedSong?.id === songId ? selectedSong :
+      songs.find(song => song.id === songId) || null;
+    setViewingSongPreview(previewSong);
     setViewingSongId(songId);
     setCurrentView('song');
     window.history.pushState({}, '', `/song/${songId}`);
@@ -228,6 +261,7 @@ function AppContent() {
   // Back from Song Handler
   const handleBackFromSong = () => {
     setViewingSongId(null);
+    setViewingSongPreview(null);
     setCurrentView('create');
     window.history.pushState({}, '', '/');
   };
@@ -383,6 +417,13 @@ function AppContent() {
     }
   }, [currentView, loadReferenceTracks]);
 
+  useEffect(() => {
+    if (currentView !== 'song' || !currentSong?.id) return;
+    if (viewingSongId === currentSong.id) return;
+    setViewingSongPreview(currentSong);
+    setViewingSongId(currentSong.id);
+  }, [currentView, currentSong?.id, viewingSongId]);
+
   // Player Logic
   const getActiveQueue = (song?: Song) => {
     if (playQueue.length > 0) return playQueue;
@@ -429,6 +470,7 @@ function AppContent() {
       if (candidate.audioUrl && !candidate.isGenerating) {
         setQueueIndex(nextIndex);
         setCurrentSong(candidate);
+        setSelectedSong(candidate);
         setIsPlaying(true);
         return;
       }
@@ -474,6 +516,7 @@ function AppContent() {
       if (candidate.audioUrl && !candidate.isGenerating) {
         setQueueIndex(prevIndex);
         setCurrentSong(candidate);
+        setSelectedSong(candidate);
         setIsPlaying(true);
         return;
       }
@@ -762,8 +805,14 @@ function AppContent() {
     duration: '--:--',
     createdAt: createdAt ? new Date(createdAt) : new Date(),
     isGenerating: true,
+    stage: 'Queued',
     tags: params.customMode ? ['custom'] : ['simple'],
     isPublic: true,
+    userId: user?.id,
+    creator: user?.username,
+    creator_avatar: user?.avatar_url,
+    ditModel: params.ditModel,
+    generationParams: params,
   });
 
   // Handlers
@@ -788,8 +837,14 @@ function AppContent() {
       duration: '--:--',
       createdAt: new Date(),
       isGenerating: true,
+      stage: 'Submitting job...',
       tags: params.customMode ? ['custom'] : ['simple'],
-      isPublic: true
+      isPublic: true,
+      userId: user?.id,
+      creator: user?.username,
+      creator_avatar: user?.avatar_url,
+      ditModel: params.ditModel,
+      generationParams: params,
     };
 
     setSongs(prev => [tempSong, ...prev]);
@@ -852,6 +907,13 @@ function AppContent() {
         trackName: params.trackName,
         completeTrackClasses: params.completeTrackClasses,
         isFormatCaption: params.isFormatCaption,
+        ditModel: params.ditModel,
+        dcwEnabled: params.dcwEnabled,
+        dcwMode: params.dcwMode,
+        dcwScaler: params.dcwScaler,
+        dcwHighScaler: params.dcwHighScaler,
+        dcwWavelet: params.dcwWavelet,
+        vaeModel: params.vaeModel,
       }, token);
 
       beginPollingJob(job.jobId, tempId);
@@ -961,6 +1023,26 @@ function AppContent() {
       setSelectedSong(song);
     }
     setShowRightSidebar(true);
+  };
+
+  const playSongAtTime = (song: Song, time: number) => {
+    if (!song.audioUrl) {
+      showToast(t('songNotAvailable'), 'error');
+      return;
+    }
+
+    const safeTime = Math.max(0, time);
+    if (currentSong?.id === song.id) {
+      handleSeek(safeTime);
+      setIsPlaying(true);
+      setSelectedSong(song);
+      setShowRightSidebar(true);
+      return;
+    }
+
+    pendingSeekRef.current = safeTime;
+    playSong(song);
+    setIsPlaying(true);
   };
 
   const handleSeek = (time: number) => {
@@ -1240,6 +1322,7 @@ function AppContent() {
         return (
           <UserProfile
             username={viewingUsername}
+            initialUser={viewingProfilePreview}
             onBack={handleBackFromProfile}
             onPlaySong={playSong}
             onNavigateToProfile={handleNavigateToProfile}
@@ -1271,11 +1354,14 @@ function AppContent() {
         return (
           <SongProfile
             songId={viewingSongId}
+            initialSong={viewingSongPreview}
             onBack={handleBackFromSong}
             onPlay={playSong}
             onNavigateToProfile={handleNavigateToProfile}
             currentSong={currentSong}
             isPlaying={isPlaying}
+            currentTime={currentTime}
+            onPlayAtTime={playSongAtTime}
             likedSongIds={likedSongIds}
             onToggleLike={toggleLike}
           />
@@ -1442,6 +1528,7 @@ function AppContent() {
         isLiked={currentSong ? likedSongIds.has(currentSong.id) : false}
         onToggleLike={() => currentSong && toggleLike(currentSong.id)}
         onNavigateToSong={handleNavigateToSong}
+        onNavigateToProfile={handleNavigateToProfile}
         onOpenVideo={() => currentSong && openVideoGenerator(currentSong)}
         onReusePrompt={() => currentSong && handleReuse(currentSong)}
         onAddToPlaylist={() => currentSong && openAddToPlaylistModal(currentSong)}

--- a/components/CreatePanel.tsx
+++ b/components/CreatePanel.tsx
@@ -109,6 +109,29 @@ const VOCAL_LANGUAGE_KEYS = [
   { value: 'zh', key: 'vocalChineseMandarin' as const },
 ];
 
+const normalizeLyricsInput = (value: string): string => {
+  let normalized = value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const trimmed = normalized.trim();
+
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed === 'string') {
+        normalized = parsed;
+      }
+    } catch {
+      // Fall through to targeted escape cleanup below.
+    }
+  }
+
+  return normalized
+    .replace(/\\r\\n/g, '\n')
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n');
+};
+
 export const CreatePanel: React.FC<CreatePanelProps> = ({
   onGenerate,
   isGenerating,
@@ -216,6 +239,14 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
   const [isFormatCaption, setIsFormatCaption] = useState(false);
   const [maxDurationWithLm, setMaxDurationWithLm] = useState(240);
   const [maxDurationWithoutLm, setMaxDurationWithoutLm] = useState(240);
+  const [gpuMemoryGb, setGpuMemoryGb] = useState<number | null>(null);
+
+   // DCW Parameters
+  const [dcwEnabled, setDcwEnabled] = useState(true);
+  const [dcwMode, setDcwMode] = useState('double');
+  const [dcwScaler, setDcwScaler] = useState(0.05);
+  const [dcwHighScaler, setDcwHighScaler] = useState(0.02);
+  const [dcwWavelet, setDcwWavelet] = useState('haar');
 
   // LoRA Parameters
   const [showLoraPanel, setShowLoraPanel] = useState(false);
@@ -237,6 +268,15 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
   // Available models fetched from backend
   const [fetchedModels, setFetchedModels] = useState<{ name: string; is_active: boolean; is_preloaded: boolean }[]>([]);
 
+  // VAE selection
+  const [selectedVae, setSelectedVae] = useState<string>(() => {
+    return localStorage.getItem('ace-vae') || 'official';
+  });
+  const [fetchedVaeModels, setFetchedVaeModels] = useState<{ name: string; is_preloaded: boolean }[]>([]);
+  const [showVaeMenu, setShowVaeMenu] = useState(false);
+  const vaeMenuRef = useRef<HTMLDivElement>(null);
+
+
   // Fallback model list when backend is unavailable
   const availableModels = useMemo(() => {
     if (fetchedModels.length > 0) {
@@ -249,8 +289,19 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
       { id: 'acestep-v15-turbo-shift1', name: 'acestep-v15-turbo-shift1' },
       { id: 'acestep-v15-turbo-shift3', name: 'acestep-v15-turbo-shift3' },
       { id: 'acestep-v15-turbo-continuous', name: 'acestep-v15-turbo-continuous' },
+      { id: 'acestep-v15-xl-turbo', name: 'acestep-v15-xl-turbo' },
     ];
   }, [fetchedModels]);
+
+  const availableVaeModels = useMemo(() => {
+    if (fetchedVaeModels.length > 0) {
+      return fetchedVaeModels.map(v => ({ id: v.name, name: v.name, is_preloaded: v.is_preloaded }));
+    }
+    return [
+      { id: 'official', name: 'official', is_preloaded: true },
+      { id: 'scragvae', name: 'scragvae', is_preloaded: false },
+    ];
+  }, [fetchedVaeModels]);
 
   // Map model ID to short display name
   const getModelDisplayName = (modelId: string): string => {
@@ -261,8 +312,30 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
       'acestep-v15-turbo-shift3': '1.5TS3',
       'acestep-v15-turbo-continuous': '1.5TC',
       'acestep-v15-turbo': '1.5T',
+      'acestep-v15-xl-turbo': '1.5XL-T',
     };
     return mapping[modelId] || modelId;
+  };
+
+  const getLmModelOptionLabel = (modelId: string): string => {
+    const gpu = gpuMemoryGb;
+    if (modelId.includes('0.6B')) {
+      if (gpu === null) return '0.6B - Low VRAM / safest';
+      return `0.6B - Safe on your ${gpu}GB GPU`;
+    }
+    if (modelId.includes('1.7B')) {
+      if (gpu === null) return '1.7B - Balanced';
+      if (gpu < 8) return `1.7B - Risky on your ${gpu}GB GPU`;
+      if (gpu < 16) return `1.7B - Balanced on your ${gpu}GB GPU`;
+      return `1.7B - Safe on your ${gpu}GB GPU`;
+    }
+    if (modelId.includes('4B')) {
+      if (gpu === null) return '4B - Best quality, high VRAM';
+      if (gpu < 12) return `4B - High VRAM, risky on your ${gpu}GB GPU`;
+      if (gpu < 20) return `4B - High VRAM, may need offload on your ${gpu}GB GPU`;
+      return `4B - Best quality, suitable for your ${gpu}GB GPU`;
+    }
+    return modelId;
   };
 
   // Check if model is a turbo variant
@@ -352,6 +425,19 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
       return () => document.removeEventListener('mousedown', handleClickOutside);
     }
   }, [showModelMenu]);
+
+  // Close VAE menu when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (vaeMenuRef.current && !vaeMenuRef.current.contains(event.target as Node)) {
+        setShowVaeMenu(false);
+      }
+    };
+    if (showVaeMenu) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [showVaeMenu]);
 
   // Auto-unload LoRA when model changes
   useEffect(() => {
@@ -451,7 +537,7 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
     reader.onload = (ev) => {
       try {
         const data = JSON.parse(ev.target?.result as string);
-        if (data.lyrics !== undefined) setLyrics(data.lyrics);
+        if (data.lyrics !== undefined) setLyrics(normalizeLyricsInput(String(data.lyrics)));
         if (data.style !== undefined) setStyle(data.style);
         if (data.title !== undefined) setTitle(data.title);
         if (data.caption !== undefined) setStyle(data.caption);
@@ -490,7 +576,7 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
   useEffect(() => {
     if (initialData) {
       setCustomMode(true);
-      setLyrics(initialData.song.lyrics);
+      setLyrics(normalizeLyricsInput(initialData.song.lyrics));
       setStyle(initialData.song.style);
       setTitle(initialData.song.title);
       setInstrumental(initialData.song.lyrics.length === 0);
@@ -569,6 +655,10 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
             localStorage.setItem('ace-model', active.name);
           }
         }
+        const vaes = data.vaeModels || [];
+        if (vaes.length > 0) {
+          setFetchedVaeModels(vaes);
+        }
       }
     } catch {
       // ignore - will use fallback model list
@@ -589,6 +679,9 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
         }
         if (typeof data.max_duration_without_lm === 'number') {
           setMaxDurationWithoutLm(data.max_duration_without_lm);
+        }
+        if (typeof data.gpu_memory_gb === 'number') {
+          setGpuMemoryGb(Math.round(data.gpu_memory_gb));
         }
       } catch {
         // ignore limits fetch failures
@@ -696,7 +789,7 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
     try {
       const result = await generateApi.formatInput({
         caption: style,
-        lyrics: lyrics,
+        lyrics: normalizeLyricsInput(lyrics),
         bpm: bpm > 0 ? bpm : undefined,
         duration: duration > 0 ? duration : undefined,
         keyScale: keyScale || undefined,
@@ -711,7 +804,7 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
       if (result.caption || result.lyrics || result.bpm || result.duration) {
         // Update fields with LLM-generated values
         if (target === 'style' && result.caption) setStyle(result.caption);
-        if (target === 'lyrics' && result.lyrics) setLyrics(result.lyrics);
+        if (target === 'lyrics' && result.lyrics) setLyrics(normalizeLyricsInput(result.lyrics));
         if (result.bpm && result.bpm > 0) setBpm(result.bpm);
         if (result.duration && result.duration > 0) setDuration(result.duration);
         if (result.key_scale) setKeyScale(result.key_scale);
@@ -820,7 +913,7 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
       }
       const data = await response.json();
       if (data.lyrics) {
-        setLyrics(prev => prev || data.lyrics);
+        setLyrics(prev => prev || normalizeLyricsInput(data.lyrics));
       }
     } catch (err) {
       if (controller.signal.aborted) return;
@@ -966,6 +1059,11 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
   };
 
   const handleGenerate = () => {
+    const normalizedLyrics = normalizeLyricsInput(lyrics);
+    if (normalizedLyrics !== lyrics) {
+      setLyrics(normalizedLyrics);
+    }
+
     const styleWithGender = (() => {
       if (!vocalGender) return style;
       const genderHint = vocalGender === 'male' ? 'Male vocals' : 'Female vocals';
@@ -987,8 +1085,8 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
       onGenerate({
         customMode,
         songDescription: customMode ? undefined : songDescription,
-        prompt: lyrics,
-        lyrics,
+        prompt: normalizedLyrics,
+        lyrics: normalizedLyrics,
         style: styleWithGender,
         title: bulkCount > 1 ? `${title} (${i + 1})` : title,
         ditModel: selectedModel,
@@ -1049,6 +1147,12 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
         })(),
         isFormatCaption,
         loraLoaded,
+        dcwEnabled,
+        dcwMode,
+        dcwScaler,
+        dcwHighScaler,
+        dcwWavelet,
+        vaeModel: selectedVae,
       });
     }
 
@@ -1121,13 +1225,18 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
         />
 
         {/* Header - Mode Toggle & Model Selection */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse"></div>
-            <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400">ACE-Step v1.5</span>
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+          <div className="flex items-center gap-2 text-zinc-500 dark:text-zinc-400">
+            <div className="flex h-4 items-end gap-0.5" aria-hidden="true">
+              <span className="w-0.5 h-2 rounded-full bg-[#8fbc8f]" />
+              <span className="w-0.5 h-3.5 rounded-full bg-[#8fbc8f]" />
+              <span className="w-0.5 h-2.5 rounded-full bg-[#8fbc8f]" />
+              <span className="w-0.5 h-4 rounded-full bg-[#8fbc8f]" />
+            </div>
+            <span className="hidden sm:inline text-xs font-semibold tracking-wide">Create Studio</span>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="justify-self-center">
             {/* Mode Toggle */}
             <div className="flex items-center bg-zinc-200 dark:bg-black/40 rounded-lg p-1 border border-zinc-300 dark:border-white/5">
               <button
@@ -1144,7 +1253,10 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
               </button>
             </div>
 
-            {/* Model Selection */}
+            {/* Model Selection (DiT模型选择) */}
+          </div>
+
+          <div className="justify-self-end">
             <div className="relative" ref={modelMenuRef}>
               <button
                 onClick={() => setShowModelMenu(!showModelMenu)}
@@ -1202,9 +1314,64 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
                 </div>
               )}
             </div>
+
+           
+            
+          </div>
+          
+        </div>
+        {/* VAE Selection (VAE模型选择) */}
+        <div className='flex item-center justify-between'>
+          <label className="text-xs font-bold text-zinc-500 dark:text-zinc-400 uppercase tracking-wide px-1">VAE Select</label>
+          <div className="relative" ref={vaeMenuRef}>
+            <button
+              type="button"
+              onClick={() => setShowVaeMenu(!showVaeMenu)}
+              className="bg-zinc-200 dark:bg-black/40 border border-zinc-300 dark:border-white/5 rounded-md px-2 py-1 text-[11px] font-medium text-zinc-900 dark:text-white hover:bg-zinc-300 dark:hover:bg-black/50 transition-colors flex items-center gap-1"
+              disabled={availableVaeModels.length === 0}
+            >
+              {availableVaeModels.length === 0 ? '...' : (selectedVae === 'official' ? 'official' : selectedVae)}
+              <ChevronDown size={10} className="text-zinc-600 dark:text-zinc-400" />
+            </button>
+            {/* Floating VAE Menu */}
+            {showVaeMenu && availableVaeModels.length > 0 && (
+              <div className="absolute top-full right-0 mt-1 w-64 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl shadow-2xl z-50 overflow-hidden">
+                <div className="max-h-64 overflow-y-auto custom-scrollbar">
+                  {availableVaeModels.map(vae => (
+                    <button
+                      key={vae.id}
+                      type="button"
+                      onClick={() => {
+                        setSelectedVae(vae.id);
+                        localStorage.setItem('ace-vae', vae.id);
+                        setShowVaeMenu(false);
+                      }}
+                      className={`w-full px-4 py-2.5 text-left hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors border-b border-zinc-100 dark:border-zinc-800 last:border-b-0 ${
+                        selectedVae === vae.id ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-semibold text-zinc-900 dark:text-white">
+                          {vae.id === 'official' ? 'official' : vae.name}
+                        </span>
+                        {vae.is_preloaded ? (
+                          <span className="px-1.5 py-0.5 rounded text-[8px] font-bold bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">
+                            Ready
+                          </span>
+                        ) : (
+                          <span className="px-1.5 py-0.5 rounded text-[8px] font-bold bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
+                            Download
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         </div>
-
+        
         {/* SIMPLE MODE */}
         {!customMode && (
           <div className="space-y-5">
@@ -1585,7 +1752,7 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
               <textarea
                 disabled={instrumental}
                 value={lyrics}
-                onChange={(e) => setLyrics(e.target.value)}
+                onChange={(e) => setLyrics(normalizeLyricsInput(e.target.value))}
                 placeholder={instrumental ? t('instrumental') + ' mode' : t('lyricsPlaceholder')}
                 className={`w-full bg-transparent p-3 text-sm text-zinc-900 dark:text-white placeholder-zinc-400 dark:placeholder-zinc-600 focus:outline-none resize-none font-mono leading-relaxed ${instrumental ? 'opacity-30 cursor-not-allowed' : ''}`}
                 style={{ height: `${lyricsHeight}px` }}
@@ -1600,7 +1767,7 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
             </div>
 
             {/* Style Input */}
-            <div className="bg-white dark:bg-suno-card rounded-xl border border-zinc-200 dark:border-white/5 overflow-hidden transition-colors group focus-within:border-zinc-400 dark:focus-within:border-white/20">
+            <div className="relative bg-white dark:bg-suno-card rounded-xl border border-zinc-200 dark:border-white/5 overflow-hidden transition-colors group focus-within:border-zinc-400 dark:focus-within:border-white/20">
               <div className="flex items-center justify-between px-3 py-2.5 bg-zinc-50 dark:bg-white/5 border-b border-zinc-100 dark:border-white/5">
                 <div>
                   <div className="flex items-center gap-2">
@@ -1621,12 +1788,14 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
                     className="p-1.5 hover:bg-zinc-200 dark:hover:bg-white/10 rounded transition-colors text-zinc-500 hover:text-black dark:hover:text-white"
                     title={t('refreshGenres')}
                     onClick={refreshMusicTags}
+                    disabled={isFormattingStyle}
                   >
                     <Dices size={14} />
                   </button>
                   <button
                     className="p-1.5 hover:bg-zinc-200 dark:hover:bg-white/10 rounded text-zinc-500 hover:text-black dark:hover:text-white transition-colors"
                     onClick={() => setStyle('')}
+                    disabled={isFormattingStyle}
                   >
                     <Trash2 size={14} />
                   </button>
@@ -1643,8 +1812,9 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
               <textarea
                 value={style}
                 onChange={(e) => setStyle(e.target.value)}
+                disabled={isFormattingStyle}
                 placeholder={t('stylePlaceholder')}
-                className="w-full h-20 bg-transparent p-3 text-sm text-zinc-900 dark:text-white placeholder-zinc-400 dark:placeholder-zinc-600 focus:outline-none resize-none"
+                className={`w-full h-20 bg-transparent p-3 text-sm text-zinc-900 dark:text-white placeholder-zinc-400 dark:placeholder-zinc-600 focus:outline-none resize-none ${isFormattingStyle ? 'cursor-not-allowed' : ''}`}
               />
               <div className="px-3 pb-3 space-y-3">
                 {/* Quick Tags */}
@@ -1653,6 +1823,7 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
                     <button
                       key={tag}
                       onClick={() => setStyle(prev => prev ? `${prev}, ${tag}` : tag)}
+                      disabled={isFormattingStyle}
                       className="text-[10px] font-medium bg-zinc-100 dark:bg-white/5 hover:bg-zinc-200 dark:hover:bg-white/10 text-zinc-600 dark:text-zinc-400 hover:text-black dark:hover:text-white px-2.5 py-1 rounded-full transition-colors border border-zinc-200 dark:border-white/5"
                     >
                       {tag}
@@ -1660,6 +1831,14 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
                   ))}
                 </div>
               </div>
+              {isFormattingStyle && (
+                <div className="absolute inset-0 z-20 flex items-center justify-center bg-white/65 dark:bg-black/55 backdrop-blur-[2px]">
+                  <div className="flex items-center gap-2 rounded-full border border-zinc-200 dark:border-white/10 bg-white/80 dark:bg-zinc-900/80 px-4 py-2 text-xs font-bold text-zinc-700 dark:text-zinc-200 shadow-lg">
+                    <Loader2 size={14} className="animate-spin text-pink-500" />
+                    <span>Thinking...</span>
+                  </div>
+                </div>
+              )}
             </div>
 
             {/* Title Input */}
@@ -1981,7 +2160,115 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
               helpText={t('howCloselyFollowPrompt')}
               title="How strongly the model follows the prompt. Higher = stricter, lower = freer."
             />
-
+            {/* DCW Settings Section */}
+            <div className="grid space-y-1.5">
+              {/* <h4 className="text-xs font-bold text-zinc-500 dark:text-zinc-400 uppercase tracking-wide">
+               
+              </h4> */}
+              <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-zinc-600 dark:text-zinc-400" title="Enable Dual Conditioning Wavelet guidance.">
+                    DCW Settings
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setDcwEnabled(!dcwEnabled)}
+                    className={`w-10 h-5 rounded-full flex items-center transition-colors duration-200 px-0.5 border border-zinc-200 dark:border-white/5 ${dcwEnabled ? 'bg-pink-600' : 'bg-zinc-300 dark:bg-black/40'} cursor-pointer`}
+                  >
+                    <div className={`w-4 h-4 rounded-full bg-white transform transition-transform duration-200 shadow-sm ${dcwEnabled ? 'translate-x-5' : 'translate-x-0'}`} />
+                  </button>
+              </div>
+              
+              {dcwEnabled && (
+                <div className="space-y-3">
+                  <div className='grid grid-cols-2 gap-3'>
+                    <div className="space-y-1.5">
+                      <div className="space-y-1">
+                        <label
+                          className="text-[10px] font-medium text-zinc-500 dark:text-zinc-400"
+                          title="Wavelet family used by DCW. Haar is fast and stable; DB/Sym/Coif variants can sound slightly smoother or different, but may be less predictable."
+                        >
+                          DCW Wavelet Base
+                        </label>
+                        <select
+                          value={dcwWavelet}
+                          onChange={(e) => setDcwWavelet(e.target.value)}
+                          className="w-full bg-zinc-50 dark:bg-black/20 border border-zinc-200 dark:border-white/10 rounded-lg px-2 py-1 text-xs text-zinc-900 dark:text-white focus:outline-none cursor-pointer [&>option]:bg-white [&>option]:dark:bg-zinc-800"
+                        >
+                          <option value="haar">Haar</option>
+                          <option value="db2">DB2</option>
+                          <option value="db4">DB4</option>
+                          <option value="sym4">Sym4</option>
+                          <option value="sym8">Sym8</option>
+                          <option value="coif2">Coif2</option>
+                        </select>
+                      </div>
+                    </div>
+                    <div className="space-y-1.5">
+                      <div className="space-y-1">
+                          <label
+                            className="text-[10px] font-medium text-zinc-500 dark:text-zinc-400 "
+                            title="Which frequency bands DCW emphasizes. Low = low-frequency structure, High = high-frequency detail, Double = both, Pix = pixel-style wavelet behavior, None = disable DCW mode."
+                          >
+                            DCW Mode
+                          </label>
+                          <select
+                            value={dcwMode}
+                            onChange={(e) => setDcwMode(e.target.value)}
+                            className="w-full bg-zinc-50 dark:bg-black/20 border border-zinc-200 dark:border-white/10 rounded-lg px-2 py-1 text-xs text-zinc-900 dark:text-white focus:outline-none cursor-pointer [&>option]:bg-white [&>option]:dark:bg-zinc-800"
+                          >
+                            <option value="low">Low</option>
+                            <option value="double">Double</option>
+                            <option value="high">High</option>
+                            <option value="pix">Pix</option>
+                            <option value="none">None</option>
+                          </select>
+                      </div>
+                    </div>
+                  </div>
+                  
+                  <div className="space-y-1">
+                    <div className="flex justify-between items-center text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                      <span
+                        className=""
+                        title="Overall DCW strength. Higher values can make conditioning stronger, but too high may cause artifacts or reduce naturalness. Small values are usually safer."
+                      >
+                        DCW Scaler
+                      </span>
+                      <span>{dcwScaler}</span>
+                    </div>
+                    <input
+                      type="range"
+                      min="0.0"
+                      max="1.0"
+                      step="0.01"
+                      value={dcwScaler}
+                      onChange={(e) => setDcwScaler(parseFloat(e.target.value))}
+                      className="w-full h-1 bg-zinc-200 dark:bg-zinc-700 rounded-lg appearance-none cursor-pointer accent-pink-600"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <div className="flex justify-between items-center text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                      <span
+                        className=""
+                        title="Extra strength for high-frequency DCW detail. Higher values can add brightness/detail, but too much may create harshness, noise, or unstable texture."
+                      >
+                        DCW High Scaler
+                      </span>
+                      <span>{dcwHighScaler}</span>
+                    </div>
+                    <input
+                      type="range"
+                      min="0.0"
+                      max="1.0"
+                      step="0.01"
+                      value={dcwHighScaler}
+                      onChange={(e) => setDcwHighScaler(parseFloat(e.target.value))}
+                      className="w-full h-1 bg-zinc-200 dark:bg-zinc-700 rounded-lg appearance-none cursor-pointer accent-pink-600"
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
             {/* Audio Format & Inference Method */}
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
@@ -2030,11 +2317,15 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
                 onChange={(e) => { const v = e.target.value; setLmModel(v); localStorage.setItem('ace-lmModel', v); }}
                 className="w-full bg-zinc-50 dark:bg-black/20 border border-zinc-200 dark:border-white/10 rounded-lg px-2 py-1.5 text-xs text-zinc-900 dark:text-white focus:outline-none"
               >
-                <option value="acestep-5Hz-lm-0.6B">{t('lmModel06B')}</option>
-                <option value="acestep-5Hz-lm-1.7B">{t('lmModel17B')}</option>
-                <option value="acestep-5Hz-lm-4B">{t('lmModel4B')}</option>
+                <option value="acestep-5Hz-lm-0.6B">{getLmModelOptionLabel('acestep-5Hz-lm-0.6B')}</option>
+                <option value="acestep-5Hz-lm-1.7B">{getLmModelOptionLabel('acestep-5Hz-lm-1.7B')}</option>
+                <option value="acestep-5Hz-lm-4B">{getLmModelOptionLabel('acestep-5Hz-lm-4B')}</option>
               </select>
-              <p className="text-[10px] text-zinc-500">{t('lmModelHint')}</p>
+              <p className="text-[10px] text-zinc-500">
+                {gpuMemoryGb === null
+                  ? 'Choose smaller models for lower VRAM GPUs. Risk hints appear when GPU memory is detected.'
+                  : `Detected GPU memory: ${gpuMemoryGb}GB. Risk hints are advisory; you can still choose any model.`}
+              </p>
             </div>
 
             {/* Seed */}
@@ -2434,6 +2725,7 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({
                 {t('getLrcLyrics')}
               </label>
             </div>
+          
           </div>
         )}
       </div>

--- a/components/Player.tsx
+++ b/components/Player.tsx
@@ -29,6 +29,7 @@ interface PlayerProps {
     isLiked: boolean;
     onToggleLike: () => void;
     onNavigateToSong?: (songId: string) => void;
+    onNavigateToProfile?: (username: string) => void;
     onOpenVideo?: () => void;
     onReusePrompt?: () => void;
     onAddToPlaylist?: () => void;
@@ -57,6 +58,7 @@ export const Player: React.FC<PlayerProps> = ({
     isLiked,
     onToggleLike,
     onNavigateToSong,
+    onNavigateToProfile,
     onOpenVideo,
     onReusePrompt,
     onAddToPlaylist,
@@ -196,7 +198,16 @@ export const Player: React.FC<PlayerProps> = ({
                                 >
                                     {currentSong.title}
                                 </h2>
-                                <p className="text-sm text-zinc-500 dark:text-white/60 truncate mt-1">
+                                <p
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        if (currentSong.creator) {
+                                            setIsFullscreen(false);
+                                            onNavigateToProfile?.(currentSong.creator);
+                                        }
+                                    }}
+                                    className={`text-sm text-zinc-500 dark:text-white/60 truncate mt-1 ${currentSong.creator ? 'cursor-pointer hover:underline' : ''}`}
+                                >
                                     {currentSong.creator || 'Unknown Artist'}
                                 </p>
                             </div>
@@ -457,7 +468,15 @@ export const Player: React.FC<PlayerProps> = ({
                                 >
                                     {currentSong.title}
                                 </h2>
-                                <p className="text-base lg:text-lg text-zinc-500 dark:text-white/60 truncate mt-2">
+                                <p
+                                    onClick={() => {
+                                        if (currentSong.creator) {
+                                            setIsFullscreen(false);
+                                            onNavigateToProfile?.(currentSong.creator);
+                                        }
+                                    }}
+                                    className={`text-base lg:text-lg text-zinc-500 dark:text-white/60 truncate mt-2 ${currentSong.creator ? 'cursor-pointer hover:underline' : ''}`}
+                                >
                                     {currentSong.creator || 'Unknown Artist'}
                                 </p>
                             </div>
@@ -672,7 +691,12 @@ export const Player: React.FC<PlayerProps> = ({
                         >
                             {currentSong.title}
                         </h4>
-                        <p className="text-[10px] sm:text-xs text-zinc-500 dark:text-zinc-400 truncate hover:underline cursor-pointer">{currentSong.creator || 'Unknown Artist'}</p>
+                        <p
+                            onClick={() => currentSong.creator && onNavigateToProfile?.(currentSong.creator)}
+                            className={`text-[10px] sm:text-xs text-zinc-500 dark:text-zinc-400 truncate ${currentSong.creator ? 'hover:underline cursor-pointer' : ''}`}
+                        >
+                            {currentSong.creator || 'Unknown Artist'}
+                        </p>
                     </div>
                     <button
                         onClick={onToggleLike}

--- a/components/PlaylistDetail.tsx
+++ b/components/PlaylistDetail.tsx
@@ -3,6 +3,7 @@ import { Song, Playlist, playlistsApi, songsApi, getAudioUrl } from '../services
 import { useAuth } from '../context/AuthContext';
 import { useI18n } from '../context/I18nContext';
 import { ArrowLeft, Play, MoreHorizontal, Clock, Calendar, Shuffle, Trash2, Mic2, Music } from 'lucide-react';
+import { getAvatarUrl } from '../utils/avatar';
 
 interface PlaylistDetailProps {
     playlistId: string;
@@ -140,11 +141,7 @@ export const PlaylistDetail: React.FC<PlaylistDetailProps> = ({ playlistId, onBa
                                 className="flex items-center gap-2 cursor-pointer hover:underline"
                                 onClick={() => onNavigateToProfile(playlist.creator!)}
                             >
-                                {playlist.creator_avatar ? (
-                                    <img src={playlist.creator_avatar} alt={playlist.creator} className="w-5 h-5 md:w-6 md:h-6 rounded-full object-cover" />
-                                ) : (
-                                    <div className="w-5 h-5 md:w-6 md:h-6 rounded-full bg-gradient-to-r from-green-400 to-blue-500"></div>
-                                )}
+                                <img src={getAvatarUrl(playlist.creator_avatar, playlist.creator)} alt={playlist.creator} className="w-5 h-5 md:w-6 md:h-6 rounded-full object-cover" />
                                 <span>{playlist.creator}</span>
                             </div>
                         )}

--- a/components/RightSidebar.tsx
+++ b/components/RightSidebar.tsx
@@ -7,6 +7,7 @@ import { useI18n } from '../context/I18nContext';
 import { SongDropdownMenu } from './SongDropdownMenu';
 import { ShareModal } from './ShareModal';
 import { AlbumCover } from './AlbumCover';
+import { getAvatarUrl } from '../utils/avatar';
 
 interface RightSidebarProps {
     song: Song | null;
@@ -272,8 +273,8 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({ song, onClose, onOpe
                         </div>
 
                         <div className="flex items-center gap-3">
-                            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-xs font-bold text-white shadow-sm ring-2 ring-white dark:ring-black">
-                                {song.creator ? song.creator[0].toUpperCase() : 'A'}
+                            <div className="w-8 h-8 rounded-full bg-zinc-100 dark:bg-zinc-900 flex items-center justify-center text-xs font-bold text-white shadow-sm ring-2 ring-white dark:ring-black overflow-hidden">
+                                <img src={getAvatarUrl(song.creator_avatar, song.creator)} alt={song.creator || t('anonymous')} className="w-full h-full object-cover" />
                             </div>
                             <div className="flex flex-col">
                                 <span

--- a/components/SearchPage.tsx
+++ b/components/SearchPage.tsx
@@ -4,6 +4,7 @@ import { Song, Playlist } from '../types';
 import { songsApi, usersApi, playlistsApi, searchApi, UserProfile, getAudioUrl } from '../services/api';
 import { useI18n } from '../context/I18nContext';
 import { GENRE_KEYS } from '../data/genres';
+import { getAvatarUrl } from '../utils/avatar';
 
 interface SearchPageProps {
   onPlaySong?: (song: Song, list?: Song[]) => void;
@@ -20,6 +21,25 @@ const MAX_RESULTS = 20;
 interface ExtendedSong extends Song {
   creator_avatar?: string | null;
 }
+
+const getModelDisplayName = (modelId?: string): string => {
+  if (!modelId) return 'ACE';
+  const mapping: Record<string, string> = {
+    'acestep-v1-5': '1.5',
+    'acestep-v1.5': '1.5',
+    'acestep-v1.5-turbo': '1.5T',
+    'acestep-v15-turbo': '1.5T',
+    'acestep-v1.5-xl-turbo': '1.5XL-T',
+    'acestep-v15-xl-turbo': '1.5XL-T',
+    'acestep-v1.5-turbo-s3': '1.5TS3',
+    'acestep-v15-turbo-s3': '1.5TS3',
+  };
+  return mapping[modelId] || modelId.replace(/^acestep-/, '').replace(/^v/, '').toUpperCase();
+};
+
+const getSongModelId = (song: ExtendedSong): string | undefined => {
+  return song.ditModel || song.generationParams?.ditModel || song.generationParams?.dit_model;
+};
 
 export const SearchPage: React.FC<SearchPageProps> = ({
   onPlaySong,
@@ -68,6 +88,8 @@ export const SearchPage: React.FC<SearchPageProps> = ({
     viewCount: s.view_count || s.viewCount || 0,
     creator: s.creator,
     creator_avatar: s.creator_avatar || s.creatorAvatar || null,
+    ditModel: s.dit_model || s.ditModel,
+    generationParams: s.generation_params || s.generationParams,
   });
 
   // Shuffle array randomly
@@ -451,6 +473,7 @@ const FeaturedSongCard: React.FC<FeaturedSongCardProps> = ({
 }) => {
   const [isHovered, setIsHovered] = useState(false);
   const tags = song.style?.split(',').map(t => t.trim()).filter(Boolean).slice(0, 2) || [];
+  const modelId = getSongModelId(song);
 
   return (
     <div
@@ -464,7 +487,7 @@ const FeaturedSongCard: React.FC<FeaturedSongCardProps> = ({
           alt={song.title}
           className="w-full h-full object-cover"
         />
-        <div className={`absolute inset-0 bg-black/50 flex items-center justify-center transition-opacity ${isHovered || isPlaying ? 'opacity-100' : 'opacity-0'}`}>
+        <div className={`absolute inset-0 bg-black/50 flex items-center justify-center transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
           {isPlaying ? (
             <Pause size={16} className="text-white" fill="white" />
           ) : (
@@ -477,8 +500,11 @@ const FeaturedSongCard: React.FC<FeaturedSongCardProps> = ({
         <div className="flex items-center gap-1.5 mb-0.5">
           <span className="font-semibold text-zinc-900 dark:text-white text-sm truncate max-w-[140px]">{song.title}</span>
           {song.isPublic !== false && (
-            <span className="flex-shrink-0 text-[8px] font-bold text-white bg-gradient-to-r from-pink-500 to-purple-500 px-1 py-0.5 rounded">
-              v5
+            <span
+              className="inline-flex items-center justify-center flex-shrink-0 text-[9px] font-bold text-[#16301f] bg-[#8fbc8f] border border-[#a7cda6] px-1.5 py-0.5 rounded-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]"
+              title={`DiT model: ${modelId || 'unknown'}`}
+            >
+              {getModelDisplayName(modelId)}
             </span>
           )}
         </div>
@@ -500,17 +526,11 @@ const FeaturedSongCard: React.FC<FeaturedSongCardProps> = ({
               onClick={(e) => { e.stopPropagation(); onNavigateToProfile?.(song.creator!); }}
               className="flex items-center gap-1 hover:text-pink-500 transition-colors max-w-[80px]"
             >
-              {song.creator_avatar ? (
-                <img
-                  src={song.creator_avatar}
-                  alt={song.creator}
-                  className="w-3.5 h-3.5 rounded-full object-cover"
-                />
-              ) : (
-                <div className="w-3.5 h-3.5 rounded-full bg-gradient-to-br from-pink-500 to-purple-500 flex items-center justify-center text-[7px] text-white font-bold flex-shrink-0">
-                  {song.creator.charAt(0).toUpperCase()}
-                </div>
-              )}
+              <img
+                src={getAvatarUrl(song.creator_avatar, song.creator)}
+                alt={song.creator}
+                className="w-3.5 h-3.5 rounded-full object-cover flex-shrink-0"
+              />
               <span className="truncate">{song.creator}</span>
             </button>
           )}
@@ -542,7 +562,7 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
     >
       <div className="w-[90px] h-[90px] mx-auto rounded-full overflow-hidden mb-2 ring-2 ring-transparent group-hover:ring-pink-500 transition-all shadow-lg">
         <img
-          src={creator.avatar_url || `https://api.dicebear.com/7.x/avataaars/svg?seed=${creator.username}`}
+          src={getAvatarUrl(creator.avatar_url, creator.username)}
           alt={creator.username}
           className="w-full h-full object-cover"
         />
@@ -595,7 +615,7 @@ const PlaylistCard: React.FC<PlaylistCardProps> = ({
         >
           <div className="w-4 h-4 rounded-full overflow-hidden flex-shrink-0 bg-zinc-300 dark:bg-zinc-700">
             <img
-              src={playlist.creator_avatar || `https://api.dicebear.com/7.x/avataaars/svg?seed=${playlist.creator}`}
+              src={getAvatarUrl(playlist.creator_avatar, playlist.creator)}
               alt={playlist.creator}
               className="w-full h-full object-cover"
             />

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -3,6 +3,7 @@ import { X, User as UserIcon, Palette, Info, Edit3, ExternalLink, Globe, Chevron
 import { useAuth } from '../context/AuthContext';
 import { useI18n } from '../context/I18nContext';
 import { EditProfileModal } from './EditProfileModal';
+import { getAvatarUrl } from '../utils/avatar';
 
 interface SettingsModalProps {
     isOpen: boolean;
@@ -64,12 +65,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, t
                     {/* User Profile Section */}
                     <div className="bg-zinc-50 dark:bg-zinc-800/50 rounded-xl p-6">
                         <div className="flex items-center gap-4">
-                            <div className="w-16 h-16 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-2xl font-bold text-white shadow-lg overflow-hidden">
-                                {user.avatar_url ? (
-                                    <img src={user.avatar_url} alt={user.username} className="w-full h-full object-cover" />
-                                ) : (
-                                    user.username[0].toUpperCase()
-                                )}
+                            <div className="w-16 h-16 rounded-full bg-zinc-100 dark:bg-zinc-900 flex items-center justify-center text-2xl font-bold text-white shadow-lg overflow-hidden border border-zinc-200 dark:border-white/10">
+                                <img src={getAvatarUrl(user.avatar_url, user.username)} alt={user.username} className="w-full h-full object-cover" />
                             </div>
                             <div className="flex-1">
                                 <h3 className="text-xl font-bold text-zinc-900 dark:text-white">@{user.username}</h3>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Library, Disc, Search, LogIn, LogOut, Sun, Moon, GraduationCap, Newspaper } from 'lucide-react';
 import { View } from '../types';
 import { useI18n } from '../context/I18nContext';
+import { getAvatarUrl } from '../utils/avatar';
 
 interface SidebarProps {
   currentView: View;
@@ -148,12 +149,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 `}
                 title={`${user.username} - ${t('settings')}`}
               >
-                <div className="w-6 h-6 rounded-full bg-gradient-to-br from-pink-500 to-purple-600 flex items-center justify-center text-white text-xs font-bold border border-white/20 overflow-hidden flex-shrink-0">
-                  {user.avatar_url ? (
-                    <img src={user.avatar_url} alt={user.username} className="w-full h-full object-cover" />
-                  ) : (
-                    user.username.charAt(0).toUpperCase()
-                  )}
+                <div className="w-6 h-6 rounded-full bg-zinc-100 dark:bg-zinc-900 flex items-center justify-center text-white text-xs font-bold border border-zinc-200 dark:border-white/10 overflow-hidden flex-shrink-0">
+                  <img src={getAvatarUrl(user.avatar_url, user.username)} alt={user.username} className="w-full h-full object-cover" />
                 </div>
                 {isOpen && (
                   <span className="text-sm font-medium whitespace-nowrap truncate flex-1 text-left">

--- a/components/SongList.tsx
+++ b/components/SongList.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { Song } from '../types';
-import { Play, MoreHorizontal, Heart, ThumbsDown, ListPlus, Pause, Search, Filter, Check, Globe, Lock, Loader2, ThumbsUp, Share2, Video, Info, Clock } from 'lucide-react';
+import { Play, MoreHorizontal, Heart, ThumbsDown, ListPlus, Pause, Search, Filter, Check, Globe, Lock, Loader2, ThumbsUp, Share2, Video, Info, Clock, BarChart3, X } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useI18n } from '../context/I18nContext';
 import { SongDropdownMenu } from './SongDropdownMenu';
 import { ShareModal } from './ShareModal';
 import { AlbumCover } from './AlbumCover';
 import { songsApi } from '../services/api';
+import { getAvatarUrl } from '../utils/avatar';
 
 interface SongListProps {
     songs: Song[];
@@ -41,7 +42,7 @@ type FilterType = 'liked' | 'public' | 'private' | 'generating';
 
 // Map model ID to short display name
 const getModelDisplayName = (modelId?: string): string => {
-    if (!modelId) return 'v1.5';
+    if (!modelId) return 'ACE';
     
     const mapping: Record<string, string> = {
         'acestep-v15-base': '1.5B',
@@ -50,8 +51,93 @@ const getModelDisplayName = (modelId?: string): string => {
         'acestep-v15-turbo-shift3': '1.5TS3',
         'acestep-v15-turbo-continuous': '1.5TC',
         'acestep-v15-turbo': '1.5T',
+        'acestep-v15-xl-turbo': '1.5XL-T',
     };
-    return mapping[modelId] || 'v1.5';
+    return mapping[modelId] || modelId.replace(/^acestep-/, '').replace(/^v/, '').toUpperCase();
+};
+
+const getSongModelId = (song: Song): string | undefined => {
+    return song.ditModel || song.generationParams?.ditModel || song.generationParams?.dit_model;
+};
+
+const getSongScorePayload = (song: Song): unknown => {
+    const record = song as Song & Record<string, unknown>;
+    return record.scores
+        || record.scoreDetails
+        || record.score_details
+        || song.generationParams?.scores
+        || song.generationParams?.scoreDetails
+        || song.generationParams?.score_details
+        || song.generationParams?.score;
+};
+
+const hasRequestedScores = (song: Song): boolean => {
+    return Boolean(song.generationParams?.getScores || song.generationParams?.get_scores || getSongScorePayload(song));
+};
+
+const formatScorePayload = (value: unknown): string => {
+    if (value === undefined || value === null || value === '') {
+        return 'Score output was requested, but no scorer payload was saved for this song.';
+    }
+    if (typeof value === 'string') {
+        return value
+            .replace(/^DiT Lyric Alignment Scores\s*\(Python fallback\)/i, 'Lyric Alignment Scores')
+            .replace(/\n?Sensitivity:\s*[\d.]+\s*$/i, '')
+            .trim();
+    }
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch {
+        return String(value);
+    }
+};
+
+type ParsedLyricAlignmentScore = {
+    globalScore?: string;
+    lmScore: string;
+    ditScore: string;
+    note?: string;
+};
+
+const parseLyricAlignmentScore = (text: string): ParsedLyricAlignmentScore | null => {
+    const globalMatch = text.match(/Global Quality Score:\s*([0-9.]+)/i);
+    const lmMatch = text.match(/LM lyrics alignment score:\s*([0-9.]+)/i);
+    const ditMatch = text.match(/DiT lyrics alignment score:\s*([0-9.]+)/i);
+    if (!lmMatch || !ditMatch) return null;
+
+    const noteMatch = text.match(/Global PMI quality score[^\n]+(?:\n[^\n]+)?/i);
+    return {
+        globalScore: globalMatch?.[1],
+        lmScore: lmMatch[1],
+        ditScore: ditMatch[1],
+        note: noteMatch?.[0],
+    };
+};
+
+const TooltipInfo: React.FC<{ text: string; align?: 'left' | 'right' }> = ({ text, align = 'left' }) => (
+    <span className="relative inline-flex group">
+        <Info size={13} className="text-zinc-400 group-hover:text-zinc-200 transition-colors" />
+        <span
+            className={`pointer-events-none absolute bottom-full z-[120] mb-2 hidden w-64 max-w-[min(16rem,calc(100vw-3rem))] rounded-md border border-zinc-200 bg-white px-3 py-2 text-left text-[11px] font-medium leading-relaxed text-zinc-700 shadow-xl group-hover:block dark:border-white/10 dark:bg-zinc-900 dark:text-zinc-200 ${
+                align === 'right' ? 'right-0 -translate-x-2' : 'left-0 translate-x-2'
+            }`}
+        >
+            {text}
+        </span>
+    </span>
+);
+
+const formatElapsedTime = (start: Date, now: number): string => {
+    const elapsedSec = Math.max(0, Math.floor((now - start.getTime()) / 1000));
+    const minutes = Math.floor(elapsedSec / 60);
+    const seconds = elapsedSec % 60;
+    return `${minutes}:${String(seconds).padStart(2, '0')}`;
+};
+
+const getGenerationStatusText = (song: Song, now: number): string => {
+    if (song.queuePosition) return `Queued #${song.queuePosition}`;
+    const stage = song.stage?.trim() || 'Creating audio';
+    return `${stage} · ${formatElapsedTime(song.createdAt, now)}`;
 };
 
 const createDragPreview = (element: HTMLElement) => {
@@ -116,6 +202,7 @@ export const SongList: React.FC<SongListProps> = ({
     const [isFilterOpen, setIsFilterOpen] = useState(false);
     const [isSelecting, setIsSelecting] = useState(false);
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [now, setNow] = useState(() => Date.now());
     const filterRef = useRef<HTMLDivElement>(null);
 
     const FILTERS: { id: FilterType; label: string; icon: React.ReactNode }[] = [
@@ -146,6 +233,12 @@ export const SongList: React.FC<SongListProps> = ({
             });
             return next;
         });
+    }, [songs]);
+
+    useEffect(() => {
+        if (!songs.some(song => song.isGenerating)) return;
+        const interval = window.setInterval(() => setNow(Date.now()), 1000);
+        return () => window.clearInterval(interval);
     }, [songs]);
 
     const toggleFilter = (filterId: FilterType) => {
@@ -367,6 +460,7 @@ export const SongList: React.FC<SongListProps> = ({
                                     isLiked={likedSongIds.has(item.song.id)}
                                     isPlaying={isPlaying}
                                     isOwner={user?.id === item.song.userId}
+                                    now={now}
                                     onPlay={() => onPlay(item.song)}
                                     onSelect={() => onSelect(item.song)}
                                     onToggleSelect={() => {
@@ -428,6 +522,7 @@ interface SongItemProps {
     isLiked: boolean;
     isPlaying: boolean;
     isOwner: boolean;
+    now: number;
     onPlay: () => void;
     onSelect: () => void;
     onToggleSelect: () => void;
@@ -452,6 +547,7 @@ const SongItem: React.FC<SongItemProps> = ({
     isLiked,
     isPlaying,
     isOwner,
+    now,
     onPlay,
     onSelect,
     onToggleSelect,
@@ -467,12 +563,18 @@ const SongItem: React.FC<SongItemProps> = ({
     onCoverSong
 }) => {
     const { token } = useAuth();
+    const hasMeasuredProgress = typeof song.progress === 'number' && song.progress > 0;
     const [showDropdown, setShowDropdown] = useState(false);
     const [shareModalOpen, setShareModalOpen] = useState(false);
+    const [scoreModalOpen, setScoreModalOpen] = useState(false);
     const [imageError, setImageError] = useState(false);
     const [isEditingTitle, setIsEditingTitle] = useState(false);
     const [editedTitle, setEditedTitle] = useState(song.title);
     const titleInputRef = useRef<HTMLInputElement>(null);
+    const scorePayload = getSongScorePayload(song);
+    const scoreRequested = hasRequestedScores(song);
+    const formattedScorePayload = formatScorePayload(scorePayload);
+    const lyricAlignmentScore = parseLyricAlignmentScore(formattedScorePayload);
 
     useEffect(() => {
         if (isEditingTitle && titleInputRef.current) {
@@ -593,7 +695,7 @@ const SongItem: React.FC<SongItemProps> = ({
                     </div>
                 ) : (
                     <div
-                        className={`absolute inset-0 bg-black/40 flex items-center justify-center backdrop-blur-[1px] cursor-pointer transition-opacity duration-200 ${isCurrent ? 'opacity-100' : 'opacity-0 group-hover/image:opacity-100'}`}
+                        className="absolute inset-0 bg-black/40 flex items-center justify-center backdrop-blur-[1px] cursor-pointer opacity-0 group-hover/image:opacity-100 focus-within:opacity-100 transition-opacity duration-200"
                         onClick={(e) => {
                             e.stopPropagation();
                             onPlay();
@@ -638,8 +740,11 @@ const SongItem: React.FC<SongItemProps> = ({
                                 {song.title || (song.isGenerating ? (song.queuePosition ? "Queued..." : "Creating...") : "Untitled")}
                             </h3>
                         )}
-                        <span className="inline-flex items-center justify-center text-[9px] font-bold text-white bg-gradient-to-r from-pink-500 to-purple-500 px-1.5 py-0.5 rounded-sm shadow-sm" title={`DiT model: ${song.ditModel || 'undefined'}`}>
-                            {getModelDisplayName(song.ditModel)}
+                        <span
+                            className="inline-flex items-center justify-center text-[9px] font-bold text-[#16301f] bg-[#8fbc8f] border border-[#a7cda6] px-1.5 py-0.5 rounded-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]"
+                            title={`DiT model: ${getSongModelId(song) || 'unknown'}`}
+                        >
+                            {getModelDisplayName(getSongModelId(song))}
                         </span>
                         {song.isPublic === false && (
                             <Lock size={12} className="text-zinc-400 dark:text-zinc-500" />
@@ -655,8 +760,8 @@ const SongItem: React.FC<SongItemProps> = ({
                                 }
                             }}
                         >
-                            <div className="w-4 h-4 rounded-full bg-purple-500 text-[8px] flex items-center justify-center font-bold text-white">
-                                {(song.creator?.[0] || 'U').toUpperCase()}
+                            <div className="w-4 h-4 rounded-full bg-zinc-100 dark:bg-zinc-900 text-[8px] flex items-center justify-center font-bold text-white overflow-hidden border border-zinc-200 dark:border-white/10">
+                                <img src={getAvatarUrl(song.creator_avatar, song.creator)} alt={song.creator || 'Unknown'} className="w-full h-full object-cover" />
                             </div>
                             <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors hover:underline">
                                 {song.creator || 'Unknown'}
@@ -668,14 +773,23 @@ const SongItem: React.FC<SongItemProps> = ({
                     </p>
                     {song.isGenerating && (
                         <div className="pt-2">
+                            <div className="flex items-center justify-between gap-3 text-[11px] font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+                                <span className="truncate">
+                                    {getGenerationStatusText(song, now)}
+                                </span>
+                                {hasMeasuredProgress && (
+                                    <span className="font-mono text-zinc-400 dark:text-zinc-500 flex-shrink-0">
+                                        {Math.round(Math.min(1, Math.max(0, song.progress)) * 100)}%
+                                    </span>
+                                )}
+                            </div>
                             <div className="h-1 rounded-full bg-zinc-200/70 dark:bg-white/10 overflow-hidden">
                                 <div
-                                    className={`h-full bg-gradient-to-r from-pink-500 to-purple-600 transition-all ${song.progress === undefined ? 'opacity-40' : ''}`}
+                                    className={`h-full bg-[#8fbc8f] transition-all ${!hasMeasuredProgress ? 'opacity-40 animate-pulse' : ''}`}
                                     style={{
-                                        width: `${Math.min(
-                                            100,
-                                            Math.max(0, ((song.progress ?? 0) > 1 ? (song.progress ?? 0) / 100 : (song.progress ?? 0)) * 100)
-                                        )}%`,
+                                        width: !hasMeasuredProgress
+                                            ? '18%'
+                                            : `${Math.min(100, Math.max(0, song.progress * 100))}%`,
                                     }}
                                 />
                             </div>
@@ -718,6 +832,16 @@ const SongItem: React.FC<SongItemProps> = ({
                         >
                             <Video size={16} />
                         </button>
+
+                        {scoreRequested && (
+                            <button
+                                className="p-2 rounded-full hover:bg-zinc-200 dark:hover:bg-white/5 text-zinc-400 hover:text-black dark:hover:text-white transition-colors"
+                                onClick={(e) => { e.stopPropagation(); setScoreModalOpen(true); }}
+                                title="View scores"
+                            >
+                                <BarChart3 size={16} />
+                            </button>
+                        )}
 
                         <button
                             className="p-2 rounded-full hover:bg-zinc-200 dark:hover:bg-white/5 text-zinc-400 hover:text-black dark:hover:text-white transition-colors ml-auto"
@@ -767,8 +891,8 @@ const SongItem: React.FC<SongItemProps> = ({
             {/* Timestamp */}
             <div className="text-xs font-mono text-zinc-500 dark:text-zinc-600 self-start pt-1">
                 {song.isGenerating ? (
-                    <span className={song.queuePosition ? 'text-amber-500' : 'text-pink-500'}>
-                        {song.queuePosition ? `#${song.queuePosition}` : 'Creating...'}
+                    <span className={song.queuePosition ? 'text-amber-500' : 'text-[#8fbc8f]'}>
+                        {song.queuePosition ? `#${song.queuePosition}` : formatElapsedTime(song.createdAt, now)}
                     </span>
                 ) : song.duration}
             </div>
@@ -779,6 +903,83 @@ const SongItem: React.FC<SongItemProps> = ({
             onClose={() => setShareModalOpen(false)}
             song={song}
         />
+        {scoreModalOpen && (
+            <div
+                className="fixed inset-0 z-[100] bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+                onClick={() => setScoreModalOpen(false)}
+            >
+                <div
+                    className="w-full max-w-lg rounded-xl border border-zinc-200 dark:border-white/10 bg-white dark:bg-zinc-950 shadow-2xl overflow-visible"
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-200 dark:border-white/10">
+                        <div>
+                            <h3 className="text-sm font-bold text-zinc-900 dark:text-white">Scores</h3>
+                            <p className="text-xs text-zinc-500 dark:text-zinc-400 truncate max-w-[22rem]">{song.title}</p>
+                        </div>
+                        <button
+                            className="p-2 rounded-full text-zinc-500 hover:text-zinc-900 dark:hover:text-white hover:bg-zinc-100 dark:hover:bg-white/10 transition-colors"
+                            onClick={() => setScoreModalOpen(false)}
+                            title="Close"
+                        >
+                            <X size={16} />
+                        </button>
+                    </div>
+                    <div className="p-4 space-y-4">
+                        {lyricAlignmentScore ? (
+                            <>
+                                <div>
+                                    <div className="flex items-center gap-1.5 text-sm font-semibold text-zinc-900 dark:text-white">
+                                        <span>Lyric Alignment</span>
+                                        <TooltipInfo text="A diagnostic score from ACE-Step. It estimates whether the generated vocal/lyric attention lines up with the provided lyrics. It is useful for comparing takes, not a final music-quality rating." />
+                                    </div>
+                                    <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1">
+                                        Higher values usually mean the lyrics are more clearly aligned with the generated vocal timing.
+                                    </p>
+                                </div>
+                                <div className={`grid gap-2 ${lyricAlignmentScore.globalScore ? 'grid-cols-1 sm:grid-cols-3' : 'grid-cols-1 sm:grid-cols-2'}`}>
+                                    {lyricAlignmentScore.globalScore && (
+                                        <div className="rounded-lg bg-zinc-100 dark:bg-white/5 p-3">
+                                            <div className="flex items-center gap-1.5 text-xs text-zinc-500 dark:text-zinc-400 mb-1">
+                                                <span>Global quality</span>
+                                                <TooltipInfo text="PMI-based quality score from ACE-Step. It estimates how well the generated audio codes match the prompt, lyrics, and metadata. Higher is usually better." />
+                                            </div>
+                                            <div className="text-2xl font-bold tracking-normal text-zinc-900 dark:text-white">{lyricAlignmentScore.globalScore}</div>
+                                        </div>
+                                    )}
+                                    <div className="rounded-lg bg-zinc-100 dark:bg-white/5 p-3">
+                                        <div className="flex items-center gap-1.5 text-xs text-zinc-500 dark:text-zinc-400 mb-1">
+                                            <span>LM alignment</span>
+                                            <TooltipInfo text="Alignment score measured from the lyric/text-side attention. It reflects how well lyric tokens are being tracked by the conditioning path." />
+                                        </div>
+                                        <div className="text-2xl font-bold tracking-normal text-zinc-900 dark:text-white">{lyricAlignmentScore.lmScore}</div>
+                                    </div>
+                                    <div className="rounded-lg bg-zinc-100 dark:bg-white/5 p-3">
+                                        <div className="flex items-center gap-1.5 text-xs text-zinc-500 dark:text-zinc-400 mb-1">
+                                            <span>DiT alignment</span>
+                                            <TooltipInfo
+                                                align="right"
+                                                text="Alignment score measured from the diffusion model's cross-attention. It is the closer signal for whether generated audio follows the lyric timing."
+                                            />
+                                        </div>
+                                        <div className="text-2xl font-bold tracking-normal text-zinc-900 dark:text-white">{lyricAlignmentScore.ditScore}</div>
+                                    </div>
+                                </div>
+                                {lyricAlignmentScore.note && (
+                                    <p className="rounded-lg bg-zinc-100 dark:bg-white/5 px-3 py-2 text-xs italic leading-relaxed text-zinc-500 dark:text-zinc-400">
+                                        *{lyricAlignmentScore.note}
+                                    </p>
+                                )}
+                            </>
+                        ) : (
+                            <pre className="max-h-72 overflow-auto rounded-lg bg-zinc-950 text-zinc-200 p-3 text-xs leading-relaxed whitespace-pre-wrap">
+                                {formattedScorePayload}
+                            </pre>
+                        )}
+                    </div>
+                </div>
+            </div>
+        )}
         </>
     );
 };
@@ -814,6 +1015,7 @@ const UploadItem: React.FC<{
             isLiked={false}
             isPlaying={false}
             isOwner={false}
+            now={Date.now()}
             onPlay={() => onPlay(track.audio_url, title)}
             onSelect={() => onPlay(track.audio_url, title)}
             onToggleSelect={() => undefined}

--- a/components/SongProfile.tsx
+++ b/components/SongProfile.tsx
@@ -1,22 +1,130 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { Song } from '../types';
 import { songsApi, getAudioUrl } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import { useI18n } from '../context/I18nContext';
-import { ArrowLeft, Play, Pause, Heart, Share2, MoreHorizontal, ThumbsDown, Music as MusicIcon, Edit3, Eye } from 'lucide-react';
+import { ArrowLeft, Heart, Share2, MoreHorizontal, ThumbsDown, Music as MusicIcon, Edit3, Eye, Quote } from 'lucide-react';
 import { ShareModal } from './ShareModal';
 import { SongDropdownMenu } from './SongDropdownMenu';
+import { getAvatarUrl } from '../utils/avatar';
 
 interface SongProfileProps {
     songId: string;
+    initialSong?: Song | null;
     onBack: () => void;
     onPlay: (song: Song, list?: Song[]) => void;
     onNavigateToProfile: (username: string) => void;
     currentSong?: Song | null;
     isPlaying?: boolean;
+    currentTime?: number;
+    onPlayAtTime?: (song: Song, time: number) => void;
     likedSongIds?: Set<string>;
     onToggleLike?: (songId: string) => void;
     onDelete?: (song: Song) => void;
+}
+
+interface SyncedLyricLine {
+    time: number;
+    endTime?: number;
+    text: string;
+}
+
+function cleanLyricText(text: string): string {
+    return text
+        .split('\n')
+        .map(line => line
+            .replace(/\[(?:intro|verse|pre[-\s]?chorus|chorus|bridge|outro|hook|refrain|interlude|guitar|breakdown|drop|build|solo|spoken|fade|final(?:\s+chorus)?|post[-\s]?chorus|prelude|ending|song\s+ends?)[^\]]*\]/gi, '')
+            .trim()
+        )
+        .filter(Boolean)
+        .join('\n');
+}
+
+function capitalizeLatinLineStart(text: string): string {
+    return text.replace(/^(\s*["'([{¿¡]*)([a-z])/, (_match, prefix: string, letter: string) =>
+        `${prefix}${letter.toUpperCase()}`
+    );
+}
+
+function formatDisplayLyricText(text: string): string {
+    return text
+        .split('\n')
+        .map(line => capitalizeLatinLineStart(line))
+        .join('\n');
+}
+
+function parseTimestamp(timestamp: string): number {
+    const [minutes, seconds] = timestamp.split(':');
+    return (parseInt(minutes, 10) || 0) * 60 + (parseFloat(seconds) || 0);
+}
+
+function parseLrcText(lrc: string): SyncedLyricLine[] {
+    const lines: SyncedLyricLine[] = [];
+    lrc.split('\n').forEach(rawLine => {
+        const matches = [...rawLine.matchAll(/\[(\d{2}:\d{2}(?:\.\d{1,3})?)\]/g)];
+        if (matches.length === 0) return;
+
+        const lyricText = formatDisplayLyricText(cleanLyricText(rawLine.replace(/\[(\d{2}:\d{2}(?:\.\d{1,3})?)\]/g, '')));
+        if (!lyricText) return;
+
+        matches.forEach(match => {
+            lines.push({ time: parseTimestamp(match[1]), text: lyricText });
+        });
+    });
+
+    return lines
+        .sort((a, b) => a.time - b.time)
+        .map((line, index, sorted) => ({
+            ...line,
+            endTime: sorted[index + 1]?.time,
+        }));
+}
+
+function vttTimeToSeconds(time: string): number {
+    const parts = time.trim().split(':');
+    if (parts.length === 3) {
+        return (parseInt(parts[0], 10) || 0) * 3600 + (parseInt(parts[1], 10) || 0) * 60 + (parseFloat(parts[2]) || 0);
+    }
+    if (parts.length === 2) {
+        return (parseInt(parts[0], 10) || 0) * 60 + (parseFloat(parts[1]) || 0);
+    }
+    return parseFloat(time) || 0;
+}
+
+function parseSyncedLyrics(raw: string): SyncedLyricLine[] {
+    if (!raw.trim()) return [];
+    if (!raw.trim().startsWith('WEBVTT') && !raw.includes('-->')) {
+        return parseLrcText(raw);
+    }
+
+    const lines: SyncedLyricLine[] = [];
+    const blocks = raw.replace(/\r/g, '').split(/\n\s*\n/);
+    blocks.forEach(block => {
+        const blockLines = block.split('\n').map(line => line.trim()).filter(Boolean);
+        const timingLineIndex = blockLines.findIndex(line => line.includes('-->'));
+        if (timingLineIndex === -1) return;
+
+        const [start, end] = blockLines[timingLineIndex].split('-->').map(value => value.trim().split(/\s+/)[0]);
+        const text = formatDisplayLyricText(cleanLyricText(blockLines.slice(timingLineIndex + 1).join('\n')));
+        if (!text) return;
+
+        lines.push({
+            time: vttTimeToSeconds(start),
+            endTime: end ? vttTimeToSeconds(end) : undefined,
+            text,
+        });
+    });
+
+    return lines.sort((a, b) => a.time - b.time);
+}
+
+function parseGenerationParams(value: unknown): any {
+    if (!value || typeof value !== 'string') return value;
+    try {
+        return JSON.parse(value);
+    } catch {
+        return undefined;
+    }
 }
 
 const updateMetaTags = (song: Song) => {
@@ -82,22 +190,43 @@ const resetMetaTags = () => {
     updateMeta('meta[name="twitter:image"]', defaultImage);
 };
 
-export const SongProfile: React.FC<SongProfileProps> = ({ songId, onBack, onPlay, onNavigateToProfile, currentSong, isPlaying, likedSongIds = new Set(), onToggleLike, onDelete }) => {
+export const SongProfile: React.FC<SongProfileProps> = ({ songId, initialSong = null, onBack, onPlay, onNavigateToProfile, currentSong, isPlaying, currentTime = 0, onPlayAtTime, likedSongIds = new Set(), onToggleLike, onDelete }) => {
     const { user, token } = useAuth();
     const { t } = useI18n();
-    const [song, setSong] = useState<Song | null>(null);
-    const [loading, setLoading] = useState(true);
+    const [song, setSong] = useState<Song | null>(initialSong);
+    const [loading, setLoading] = useState(!initialSong);
     const [shareModalOpen, setShareModalOpen] = useState(false);
     const [showDropdown, setShowDropdown] = useState(false);
+    const [showLyricsPanel, setShowLyricsPanel] = useState(false);
+    const [syncedLyrics, setSyncedLyrics] = useState<SyncedLyricLine[]>([]);
+    const lyricLineRefs = useRef<Record<number, HTMLDivElement | null>>({});
 
     const isCurrentSong = song && currentSong?.id === song.id;
     const isCurrentlyPlaying = isCurrentSong && isPlaying;
     const isLiked = song ? likedSongIds.has(song.id) : false;
+    const playbackTime = isCurrentSong ? currentTime : 0;
+    const shouldLoadSyncedLyrics = Boolean(song?.generationParams?.getLrc);
+    const hasRenderableLyrics = Boolean(song?.lyrics?.trim()) || syncedLyrics.length > 0;
+    const activeLyricIndex = useMemo(() => {
+        if (!syncedLyrics.length) return -1;
+        return syncedLyrics.findIndex((line, index) => {
+            const endTime = line.endTime ?? syncedLyrics[index + 1]?.time;
+            return playbackTime >= line.time && (!endTime || playbackTime < endTime);
+        });
+    }, [playbackTime, syncedLyrics]);
 
     useEffect(() => {
-        loadSongData();
-        return () => resetMetaTags();
-    }, [songId]);
+        let cancelled = false;
+        if (initialSong?.id === songId) {
+            setSong(initialSong);
+        }
+        loadSongData(songId, () => cancelled);
+        setShowLyricsPanel(false);
+        return () => {
+            cancelled = true;
+            resetMetaTags();
+        };
+    }, [songId, initialSong]);
 
     useEffect(() => {
         if (song) {
@@ -105,10 +234,11 @@ export const SongProfile: React.FC<SongProfileProps> = ({ songId, onBack, onPlay
         }
     }, [song]);
 
-    const loadSongData = async () => {
+    const loadSongData = async (targetSongId = songId, isCancelled: () => boolean = () => false) => {
         setLoading(true);
         try {
-            const response = await songsApi.getFullSong(songId, token);
+            const response = await songsApi.getFullSong(targetSongId, token);
+            if (isCancelled()) return;
 
             const transformedSong: Song = {
                 id: response.song.id,
@@ -128,17 +258,54 @@ export const SongProfile: React.FC<SongProfileProps> = ({ songId, onBack, onPlay
                 userId: response.song.user_id,
                 creator: response.song.creator,
                 creator_avatar: response.song.creator_avatar,
+                generationParams: parseGenerationParams(response.song.generation_params),
             };
 
             setSong(transformedSong);
         } catch (error) {
+            if (isCancelled()) return;
             console.error('Failed to load song:', error);
         } finally {
-            setLoading(false);
+            if (!isCancelled()) setLoading(false);
         }
     };
 
-    if (loading) {
+    useEffect(() => {
+        if (!song?.audioUrl || !shouldLoadSyncedLyrics) {
+            setSyncedLyrics([]);
+            return;
+        }
+
+        let cancelled = false;
+        const lrcUrl = song.audioUrl.replace(/\.[^/.]+$/, '.lrc');
+
+        fetch(lrcUrl)
+            .then(response => {
+                if (!response.ok) throw new Error(`LRC not found: ${response.status}`);
+                return response.text();
+            })
+            .then(text => {
+                if (cancelled) return;
+                setSyncedLyrics(parseSyncedLyrics(text));
+            })
+            .catch(() => {
+                if (!cancelled) setSyncedLyrics([]);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [song?.audioUrl, shouldLoadSyncedLyrics]);
+
+    useEffect(() => {
+        if (activeLyricIndex < 0) return;
+        lyricLineRefs.current[activeLyricIndex]?.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center',
+        });
+    }, [activeLyricIndex]);
+
+    if (loading && !song) {
         return (
             <div className="flex items-center justify-center h-full bg-zinc-50 dark:bg-black">
                 <div className="text-zinc-500 dark:text-zinc-400 flex items-center gap-2">
@@ -161,7 +328,7 @@ export const SongProfile: React.FC<SongProfileProps> = ({ songId, onBack, onPlay
     }
 
     return (
-        <div className="w-full h-full flex flex-col bg-zinc-50 dark:bg-black overflow-hidden">
+        <div className={`w-full h-full flex flex-col bg-zinc-50 dark:bg-black overflow-hidden transition-opacity duration-200 ${loading ? 'opacity-100' : 'opacity-100'}`}>
             {/* Header */}
             <div className="border-b border-zinc-200 dark:border-zinc-800 px-4 md:px-6 py-4 flex-shrink-0">
                 <button
@@ -180,12 +347,8 @@ export const SongProfile: React.FC<SongProfileProps> = ({ songId, onBack, onPlay
                                 onClick={() => song.creator && onNavigateToProfile(song.creator)}
                                 className="flex items-center gap-2 cursor-pointer hover:underline"
                             >
-                                <div className="w-6 h-6 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-xs font-bold text-white overflow-hidden">
-                                    {song.creator_avatar ? (
-                                        <img src={song.creator_avatar} alt={song.creator || 'Creator'} className="w-full h-full object-cover" />
-                                    ) : (
-                                        song.creator ? song.creator[0].toUpperCase() : 'A'
-                                    )}
+                                <div className="w-6 h-6 rounded-full bg-zinc-100 dark:bg-zinc-900 flex items-center justify-center text-xs font-bold text-white overflow-hidden border border-zinc-200 dark:border-white/10">
+                                    <img src={getAvatarUrl(song.creator_avatar, song.creator)} alt={song.creator || 'Creator'} className="w-full h-full object-cover" />
                                 </div>
                                 <span className="text-zinc-900 dark:text-white font-semibold">{song.creator || 'Anonymous'}</span>
                             </div>
@@ -225,97 +388,148 @@ export const SongProfile: React.FC<SongProfileProps> = ({ songId, onBack, onPlay
 
             {/* Content */}
             <div className="flex-1 overflow-y-auto">
-                <div className="max-w-3xl mx-auto px-4 md:px-6 py-4 md:py-6 pb-24 lg:pb-32">
+                <div className={`${showLyricsPanel ? 'max-w-6xl' : 'max-w-3xl'} mx-auto px-4 md:px-6 py-4 md:py-6 pb-24 lg:pb-32`}>
 
-                    {/* Left Column: Song Details */}
-                    <div className="space-y-4 md:space-y-6">
-                        {/* Cover Art */}
-                        <div className="relative aspect-square max-w-xs md:max-w-sm mx-auto lg:mx-0 rounded-xl overflow-hidden shadow-2xl">
-                            <img src={song.coverUrl} alt={song.title} className={`w-full h-full object-cover transition-transform duration-500 ${isCurrentlyPlaying ? 'scale-105' : ''}`} />
-                            <button
-                                onClick={() => onPlay(song)}
-                                className={`absolute inset-0 transition-colors flex items-center justify-center group ${isCurrentSong ? 'bg-black/50' : 'bg-black/40 hover:bg-black/50'}`}
-                            >
-                                <div className="w-16 h-16 md:w-20 md:h-20 rounded-full bg-white group-hover:scale-110 transition-transform flex items-center justify-center shadow-xl">
-                                    {isCurrentlyPlaying ? (
-                                        <Pause size={28} className="text-black fill-black md:w-8 md:h-8" />
-                                    ) : (
-                                        <Play size={28} className="text-black fill-black ml-1 md:w-8 md:h-8" />
-                                    )}
-                                </div>
-                            </button>
-                            {isCurrentlyPlaying && (
-                                <div className="absolute bottom-4 left-4 flex items-center gap-1">
-                                    <span className="w-1.5 h-4 bg-pink-500 rounded-full animate-pulse" style={{ animationDelay: '0ms' }} />
-                                    <span className="w-1.5 h-6 bg-pink-500 rounded-full animate-pulse" style={{ animationDelay: '150ms' }} />
-                                    <span className="w-1.5 h-3 bg-pink-500 rounded-full animate-pulse" style={{ animationDelay: '300ms' }} />
-                                    <span className="w-1.5 h-7 bg-pink-500 rounded-full animate-pulse" style={{ animationDelay: '450ms' }} />
-                                </div>
-                            )}
-                        </div>
-
-                        {/* Action Buttons */}
-                        <div className="flex items-center justify-center lg:justify-start gap-2 md:gap-3 flex-wrap">
-                            <div className="flex items-center gap-2 bg-zinc-200 dark:bg-zinc-900 px-3 py-2 rounded-full text-sm">
-                                <Eye size={16} className="text-zinc-600 dark:text-white" />
-                                <span className="text-zinc-900 dark:text-white font-semibold">{song.viewCount || 0}</span>
-                            </div>
-                            <button
-                                onClick={() => onToggleLike?.(song.id)}
-                                className={`flex items-center gap-2 px-3 py-2 rounded-full text-sm transition-colors ${isLiked ? 'bg-pink-500 text-white' : 'bg-zinc-200 dark:bg-zinc-900 hover:bg-zinc-300 dark:hover:bg-zinc-800 text-zinc-900 dark:text-white'}`}
-                            >
-                                <Heart size={16} className={isLiked ? 'fill-current' : ''} />
-                                <span className="font-semibold">{song.likeCount || 0}</span>
-                            </button>
-                            {user?.id === song.userId && (
-                                <button
-                                    onClick={() => {
-                                        if (!song.audioUrl) return;
-                                        const audioUrl = song.audioUrl.startsWith('http') ? song.audioUrl : `${window.location.origin}${song.audioUrl}`;
-                                        window.open(`/editor?audioUrl=${encodeURIComponent(audioUrl)}`, '_blank');
-                                    }}
-                                    className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-700 px-3 py-2 rounded-full text-sm font-semibold transition-colors text-white"
-                                >
-                                    <Edit3 size={16} />
-                                    <span className="hidden md:inline">Edit</span>
-                                </button>
-                            )}
-                            <button
-                                onClick={() => setShareModalOpen(true)}
-                                className="p-2 bg-zinc-200 dark:bg-zinc-900 hover:bg-zinc-300 dark:hover:bg-zinc-800 rounded-full transition-colors"
-                            >
-                                <Share2 size={16} className="text-zinc-700 dark:text-white" />
-                            </button>
-                            <div className="relative">
-                                <button
-                                    onClick={() => setShowDropdown(!showDropdown)}
-                                    className="p-2 bg-zinc-200 dark:bg-zinc-900 hover:bg-zinc-300 dark:hover:bg-zinc-800 rounded-full transition-colors"
-                                >
-                                    <MoreHorizontal size={16} className="text-zinc-700 dark:text-white" />
-                                </button>
-                                {song && (
-                                    <SongDropdownMenu
-                                        song={song}
-                                        isOpen={showDropdown}
-                                        onClose={() => setShowDropdown(false)}
-                                        isOwner={user?.id === song.userId}
-                                        onReusePrompt={() => {}}
-                                        onAddToPlaylist={() => {}}
-                                        onDelete={() => onDelete?.(song)}
-                                        onShare={() => setShareModalOpen(true)}
-                                    />
+                    <div className={showLyricsPanel ? 'grid grid-cols-1 lg:grid-cols-[minmax(280px,380px)_minmax(0,1fr)] gap-5 md:gap-8 items-start' : 'flex flex-col items-center'}>
+                        <div className="space-y-4 md:space-y-6">
+                            {/* Cover Art */}
+                            <div className="relative aspect-square max-w-xs md:max-w-sm mx-auto lg:mx-0 rounded-xl overflow-hidden shadow-2xl">
+                                <img src={song.coverUrl} alt={song.title} className="w-full h-full object-cover" />
+                                {isCurrentlyPlaying && (
+                                    <div className="absolute bottom-4 left-4 flex items-center gap-1">
+                                        <span className="w-1.5 h-4 bg-pink-500 rounded-full animate-pulse" style={{ animationDelay: '0ms' }} />
+                                        <span className="w-1.5 h-6 bg-pink-500 rounded-full animate-pulse" style={{ animationDelay: '150ms' }} />
+                                        <span className="w-1.5 h-3 bg-pink-500 rounded-full animate-pulse" style={{ animationDelay: '300ms' }} />
+                                        <span className="w-1.5 h-7 bg-pink-500 rounded-full animate-pulse" style={{ animationDelay: '450ms' }} />
+                                    </div>
                                 )}
                             </div>
-                        </div>
 
-                        {/* Lyrics */}
-                        {song.lyrics && (
-                            <div className="bg-white dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 rounded-xl p-4">
-                                <h3 className="text-sm font-semibold text-zinc-900 dark:text-white mb-3">Lyrics</h3>
-                                <div className="text-sm text-zinc-700 dark:text-zinc-300 whitespace-pre-line leading-relaxed max-h-72 md:max-h-96 overflow-y-auto">
-                                    {song.lyrics}
+                            {hasRenderableLyrics && (
+                                <div className="flex justify-center lg:justify-start">
+                                    <button
+                                        onClick={() => setShowLyricsPanel(prev => !prev)}
+                                        className={`flex items-center gap-2 px-3 py-2 rounded-full text-sm font-semibold transition-colors ${
+                                            showLyricsPanel
+                                                ? 'bg-white text-black dark:bg-white dark:text-black'
+                                                : 'bg-zinc-200 dark:bg-zinc-900 hover:bg-zinc-300 dark:hover:bg-zinc-800 text-zinc-900 dark:text-white'
+                                        }`}
+                                        title="Show lyrics"
+                                        aria-label="Show lyrics"
+                                    >
+                                        <Quote size={16} />
+                                        <span className="hidden sm:inline">Lyrics</span>
+                                    </button>
+                                </div>
+                            )}
+
+                            {/* Action Buttons */}
+                            <div className="flex items-center justify-center lg:justify-start gap-2 md:gap-3 flex-wrap">
+                                <div className="flex items-center gap-2 bg-zinc-200 dark:bg-zinc-900 px-3 py-2 rounded-full text-sm">
+                                    <Eye size={16} className="text-zinc-600 dark:text-white" />
+                                    <span className="text-zinc-900 dark:text-white font-semibold">{song.viewCount || 0}</span>
+                                </div>
+                                <button
+                                    onClick={() => onToggleLike?.(song.id)}
+                                    className={`flex items-center gap-2 px-3 py-2 rounded-full text-sm transition-colors ${isLiked ? 'bg-pink-500 text-white' : 'bg-zinc-200 dark:bg-zinc-900 hover:bg-zinc-300 dark:hover:bg-zinc-800 text-zinc-900 dark:text-white'}`}
+                                >
+                                    <Heart size={16} className={isLiked ? 'fill-current' : ''} />
+                                    <span className="font-semibold">{song.likeCount || 0}</span>
+                                </button>
+                                {user?.id === song.userId && (
+                                    <button
+                                        onClick={() => {
+                                            if (!song.audioUrl) return;
+                                            const audioUrl = song.audioUrl.startsWith('http') ? song.audioUrl : `${window.location.origin}${song.audioUrl}`;
+                                            window.open(`/editor?audioUrl=${encodeURIComponent(audioUrl)}`, '_blank');
+                                        }}
+                                        className="flex items-center gap-2 bg-indigo-600 hover:bg-indigo-700 px-3 py-2 rounded-full text-sm font-semibold transition-colors text-white"
+                                    >
+                                        <Edit3 size={16} />
+                                        <span className="hidden md:inline">Edit</span>
+                                    </button>
+                                )}
+                                <button
+                                    onClick={() => setShareModalOpen(true)}
+                                    className="p-2 bg-zinc-200 dark:bg-zinc-900 hover:bg-zinc-300 dark:hover:bg-zinc-800 rounded-full transition-colors"
+                                >
+                                    <Share2 size={16} className="text-zinc-700 dark:text-white" />
+                                </button>
+                                <div className="relative">
+                                    <button
+                                        onClick={() => setShowDropdown(!showDropdown)}
+                                        className="p-2 bg-zinc-200 dark:bg-zinc-900 hover:bg-zinc-300 dark:hover:bg-zinc-800 rounded-full transition-colors"
+                                    >
+                                        <MoreHorizontal size={16} className="text-zinc-700 dark:text-white" />
+                                    </button>
+                                    {song && (
+                                        <SongDropdownMenu
+                                            song={song}
+                                            isOpen={showDropdown}
+                                            onClose={() => setShowDropdown(false)}
+                                            isOwner={user?.id === song.userId}
+                                            onReusePrompt={() => {}}
+                                            onAddToPlaylist={() => {}}
+                                            onDelete={() => onDelete?.(song)}
+                                            onShare={() => setShareModalOpen(true)}
+                                        />
+                                    )}
                                 </div>
                             </div>
+                        </div>
+
+                        {showLyricsPanel && (
+                        <div className="bg-white dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 rounded-xl p-4 md:p-6 min-h-[22rem] lg:min-h-[28rem]">
+                            {syncedLyrics.length > 0 ? (
+                                <div className="max-h-[32rem] overflow-y-auto px-2 md:px-4 pr-5 md:pr-7">
+                                    <div className="space-y-5 py-5">
+                                        {syncedLyrics.map((line, index) => {
+                                            const isActive = index === activeLyricIndex;
+                                            const isPast = activeLyricIndex > index;
+                                            return (
+                                                <div
+                                                    key={`${line.time}-${index}`}
+                                                    role="button"
+                                                    tabIndex={0}
+                                                    onClick={() => onPlayAtTime?.(song, line.time)}
+                                                    onKeyDown={event => {
+                                                        if (event.key === 'Enter' || event.key === ' ') {
+                                                            event.preventDefault();
+                                                            onPlayAtTime?.(song, line.time);
+                                                        }
+                                                    }}
+                                                    ref={element => {
+                                                        lyricLineRefs.current[index] = element;
+                                                    }}
+                                                    className={`max-w-full whitespace-normal break-words rounded-lg py-1 text-2xl md:text-[1.7rem] font-bold leading-snug transition-colors duration-300 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-pink-500/50 ${
+                                                        isActive
+                                                            ? 'text-zinc-950 dark:text-white'
+                                                            : isPast
+                                                                ? 'text-zinc-400/70 dark:text-zinc-500/70 hover:text-zinc-600 dark:hover:text-zinc-300'
+                                                                : 'text-zinc-500 dark:text-zinc-600 hover:text-zinc-700 dark:hover:text-zinc-300'
+                                                    }`}
+                                                >
+                                                    {line.text}
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            ) : song.lyrics ? (
+                                <>
+                                <h3 className="text-sm font-semibold text-zinc-900 dark:text-white mb-4">Lyrics</h3>
+                                <div className="text-sm md:text-base text-zinc-700 dark:text-zinc-300 whitespace-pre-line leading-relaxed max-h-[32rem] overflow-y-auto pr-2">
+                                    {formatDisplayLyricText(cleanLyricText(song.lyrics))}
+                                </div>
+                                </>
+                            ) : (
+                                <div className="h-64 flex flex-col items-center justify-center text-center text-zinc-400 dark:text-zinc-600 italic">
+                                    <MusicIcon size={28} className="mb-3 opacity-60" />
+                                    <span>Instrumental</span>
+                                    <span className="text-xs not-italic mt-1">No lyrics generated</span>
+                                </div>
+                            )}
+                        </div>
                         )}
                     </div>
 

--- a/components/UserProfile.tsx
+++ b/components/UserProfile.tsx
@@ -4,9 +4,11 @@ import { usersApi, getAudioUrl, UserProfile as UserProfileType, songsApi } from 
 import { useAuth } from '../context/AuthContext';
 import { ArrowLeft, Play, Pause, Heart, Eye, Users, Music as MusicIcon, ChevronRight, Share2, MoreHorizontal, Edit3, X, Camera, Image as ImageIcon, Upload, Loader2 } from 'lucide-react';
 import { useI18n } from '../context/I18nContext';
+import { getAvatarUrl } from '../utils/avatar';
 
 interface UserProfileProps {
     username: string;
+    initialUser?: UserProfileType | null;
     onBack: () => void;
     onPlaySong: (song: Song, list?: Song[]) => void;
     onNavigateToProfile: (username: string) => void;
@@ -17,14 +19,14 @@ interface UserProfileProps {
     onToggleLike?: (songId: string) => void;
 }
 
-export const UserProfile: React.FC<UserProfileProps> = ({ username, onBack, onPlaySong, onNavigateToProfile, onNavigateToPlaylist, currentSong, isPlaying, likedSongIds = new Set(), onToggleLike }) => {
+export const UserProfile: React.FC<UserProfileProps> = ({ username, initialUser = null, onBack, onPlaySong, onNavigateToProfile, onNavigateToPlaylist, currentSong, isPlaying, likedSongIds = new Set(), onToggleLike }) => {
     const { t, language } = useI18n();
     const { user: currentUser, token } = useAuth();
-    const [profileUser, setProfileUser] = useState<UserProfileType | null>(null);
+    const [profileUser, setProfileUser] = useState<UserProfileType | null>(initialUser);
     const [publicSongs, setPublicSongs] = useState<Song[]>([]);
     const [publicPlaylists, setPublicPlaylists] = useState<Playlist[]>([]);
     const [songsTab, setSongsTab] = useState<'recent' | 'top'>('recent');
-    const [loading, setLoading] = useState(true);
+    const [loading, setLoading] = useState(!initialUser);
 
     // Edit State
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -43,10 +45,17 @@ export const UserProfile: React.FC<UserProfileProps> = ({ username, onBack, onPl
     const bannerInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
-        loadUserProfile();
-    }, [username]);
+        let cancelled = false;
+        if (initialUser?.username === username) {
+            setProfileUser(initialUser);
+        }
+        loadUserProfile(() => cancelled);
+        return () => {
+            cancelled = true;
+        };
+    }, [username, initialUser]);
 
-    const loadUserProfile = async () => {
+    const loadUserProfile = async (isCancelled: () => boolean = () => false) => {
         setLoading(true);
         try {
             const [profileRes, songsRes, playlistsRes] = await Promise.all([
@@ -54,6 +63,7 @@ export const UserProfile: React.FC<UserProfileProps> = ({ username, onBack, onPl
                 usersApi.getPublicSongs(username),
                 usersApi.getPublicPlaylists(username)
             ]);
+            if (isCancelled()) return;
 
             setProfileUser(profileRes.user);
             setEditBio(profileRes.user.bio || '');
@@ -78,9 +88,10 @@ export const UserProfile: React.FC<UserProfileProps> = ({ username, onBack, onPl
             setPublicSongs(transformedSongs);
             setPublicPlaylists(playlistsRes.playlists || []);
         } catch (error) {
+            if (isCancelled()) return;
             console.error('Failed to load user profile:', error);
         } finally {
-            setLoading(false);
+            if (!isCancelled()) setLoading(false);
         }
     };
 
@@ -155,7 +166,7 @@ export const UserProfile: React.FC<UserProfileProps> = ({ username, onBack, onPl
         }
     };
 
-    if (loading) {
+    if (loading && !profileUser) {
         return (
             <div className="flex items-center justify-center h-full bg-zinc-50 dark:bg-black">
                 <div className="text-zinc-500 dark:text-zinc-400 gap-2 flex items-center">
@@ -235,7 +246,7 @@ export const UserProfile: React.FC<UserProfileProps> = ({ username, onBack, onPl
     const displaySongs = songsTab === 'recent' ? publicSongs : [...publicSongs].sort((a, b) => (b.likeCount || 0) - (a.likeCount || 0));
 
     return (
-        <div className="w-full h-full flex flex-col bg-zinc-50 dark:bg-black overflow-y-auto pb-24 lg:pb-32 relative">
+        <div className={`w-full h-full flex flex-col bg-zinc-50 dark:bg-black overflow-y-auto pb-24 lg:pb-32 relative transition-opacity duration-200 ${loading ? 'opacity-100' : 'opacity-100'}`}>
             {/* Hero Banner */}
             <div className="relative group/banner">
                 {/* Background Banner */}
@@ -272,18 +283,19 @@ export const UserProfile: React.FC<UserProfileProps> = ({ username, onBack, onPl
                         {/* Avatar */}
                         <div className="group/avatar relative">
                             <div className={`w-24 h-24 md:w-40 md:h-40 rounded-full border-4 border-zinc-50 dark:border-black bg-zinc-200 dark:bg-zinc-800 flex items-center justify-center overflow-hidden shadow-2xl ring-4 ${badgeRing} transition-transform ${paidPulse}`}>
-                                {profileUser.avatar_url && !avatarFailed ? (
-                                    <img
-                                        src={profileUser.avatar_url}
-                                        alt={profileUser.username}
-                                        className="w-full h-full object-cover"
-                                        referrerPolicy="no-referrer"
-                                        onError={() => setAvatarFailed(true)}
-                                    />
-                                ) : (
-                                    <div className={`w-full h-full bg-gradient-to-br ${bannerGradient} flex items-center justify-center text-4xl md:text-6xl font-bold text-white`}>
-                                        {profileUser.username[0].toUpperCase()}
-                                    </div>
+                                {!avatarFailed && (
+                                  <img
+                                      src={getAvatarUrl(profileUser.avatar_url, profileUser.username)}
+                                      alt={profileUser.username}
+                                      className="w-full h-full object-cover"
+                                      referrerPolicy="no-referrer"
+                                      onError={() => setAvatarFailed(true)}
+                                  />
+                                )}
+                                {avatarFailed && (
+                                  <div className={`w-full h-full bg-gradient-to-br ${bannerGradient} flex items-center justify-center text-4xl md:text-6xl font-bold text-white`}>
+                                      {profileUser.username[0].toUpperCase()}
+                                  </div>
                                 )}
                             </div>
                             {isOwner && (

--- a/components/VideoGeneratorModal.tsx
+++ b/components/VideoGeneratorModal.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { Song } from '../types';
-import { X, Play, Pause, Download, Wand2, Image as ImageIcon, Music, Video, Loader2, Palette, Layers, Zap, Type, Monitor, Aperture, Activity, Circle, Grid, Box, BarChart2, Waves, Disc, Upload, Plus, Trash2, Settings2, MousePointer2, Search, ExternalLink, Sun, Film, Minus } from 'lucide-react';
+import { X, Play, Pause, Download, Wand2, Image as ImageIcon, Music, Video, Loader2, Palette, Layers, Zap, Type, Monitor, Aperture, Activity, Circle, Grid, Box, BarChart2, Waves, Disc, Upload, Plus, Trash2, Settings2, MousePointer2, Search, ExternalLink, Sun, Film, Minus, Shuffle } from 'lucide-react';
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { fetchFile, toBlobURL } from '@ffmpeg/util';
 import { useResponsive } from '../context/ResponsiveContext';
@@ -22,6 +22,12 @@ interface VisualizerConfig {
   secondaryColor: string;
   bgDim: number;
   particleCount: number;
+}
+
+interface ColorPreset {
+  name: string;
+  primary: string;
+  secondary: string;
 }
 
 interface EffectConfig {
@@ -92,6 +98,170 @@ const PRESETS: { id: PresetType; label: string; icon: React.ReactNode }[] = [
   { id: 'Minimal', label: 'Clean', icon: <Type size={16} /> },
 ];
 
+const COLOR_PRESETS: ColorPreset[] = [
+  { name: 'Neon Pink', primary: '#ec4899', secondary: '#8b5cf6' },
+  { name: 'Cyber Blue', primary: '#06b6d4', secondary: '#3b82f6' },
+  { name: 'Sunset', primary: '#f97316', secondary: '#eab308' },
+  { name: 'Matrix', primary: '#22c55e', secondary: '#10b981' },
+  { name: 'Fire', primary: '#ef4444', secondary: '#f97316' },
+  { name: 'Ocean', primary: '#0ea5e9', secondary: '#06b6d4' },
+  { name: 'Violet', primary: '#a855f7', secondary: '#ec4899' },
+  { name: 'Gold', primary: '#eab308', secondary: '#f59e0b' },
+  { name: 'Ice', primary: '#67e8f9', secondary: '#a5f3fc' },
+  { name: 'Mono', primary: '#ffffff', secondary: '#a1a1aa' },
+];
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function pickRandom<T>(items: T[]): T {
+  return items[randomInt(0, items.length - 1)];
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const saturation = s / 100;
+  const lightness = l / 100;
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const huePrime = h / 60;
+  const x = chroma * (1 - Math.abs((huePrime % 2) - 1));
+  const m = lightness - chroma / 2;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  if (huePrime >= 0 && huePrime < 1) {
+    r = chroma; g = x; b = 0;
+  } else if (huePrime < 2) {
+    r = x; g = chroma; b = 0;
+  } else if (huePrime < 3) {
+    r = 0; g = chroma; b = x;
+  } else if (huePrime < 4) {
+    r = 0; g = x; b = chroma;
+  } else if (huePrime < 5) {
+    r = x; g = 0; b = chroma;
+  } else {
+    r = chroma; g = 0; b = x;
+  }
+
+  return [r, g, b]
+    .map(channel => Math.round((channel + m) * 255).toString(16).padStart(2, '0'))
+    .join('')
+    .replace(/^/, '#');
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const value = hex.replace('#', '');
+  return {
+    r: parseInt(value.slice(0, 2), 16),
+    g: parseInt(value.slice(2, 4), 16),
+    b: parseInt(value.slice(4, 6), 16),
+  };
+}
+
+function colorDistance(a: string, b: string): number {
+  const first = hexToRgb(a);
+  const second = hexToRgb(b);
+  const r = first.r - second.r;
+  const g = first.g - second.g;
+  const blue = first.b - second.b;
+  return Math.sqrt(r * r + g * g + blue * blue);
+}
+
+function relativeLuminance(hex: string): number {
+  const { r, g, b } = hexToRgb(hex);
+  const channels = [r, g, b].map(value => {
+    const normalized = value / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : Math.pow((normalized + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function isPleasantColorPair(primary: string, secondary: string): boolean {
+  const primaryLum = relativeLuminance(primary);
+  const secondaryLum = relativeLuminance(secondary);
+  const distance = colorDistance(primary, secondary);
+  const averageLum = (primaryLum + secondaryLum) / 2;
+
+  return distance >= 42 && distance <= 245 && averageLum >= 0.16 && averageLum <= 0.72;
+}
+
+function colorPresetKey(preset: ColorPreset): string {
+  return `${preset.primary}-${preset.secondary}`;
+}
+
+function isDistinctFromPresets(candidate: ColorPreset, presets: ColorPreset[]): boolean {
+  return presets.every(preset => {
+    const sameDirectionDistance =
+      colorDistance(candidate.primary, preset.primary) +
+      colorDistance(candidate.secondary, preset.secondary);
+    const swappedDirectionDistance =
+      colorDistance(candidate.primary, preset.secondary) +
+      colorDistance(candidate.secondary, preset.primary);
+    return Math.min(sameDirectionDistance, swappedDirectionDistance) >= 145;
+  });
+}
+
+function createRandomColorPreset(index: number): ColorPreset {
+  const morandiFamilies = [
+    { name: 'Moss', hue: 118 },
+    { name: 'Sage', hue: 142 },
+    { name: 'Dust Rose', hue: 348 },
+    { name: 'Clay', hue: 18 },
+    { name: 'Mist Blue', hue: 204 },
+    { name: 'Mauve', hue: 284 },
+    { name: 'Cement', hue: 230 },
+    { name: 'Oat', hue: 44 },
+  ];
+  const vividFamilies = [
+    { name: 'RGB Red', hue: 0 },
+    { name: 'RGB Green', hue: 132 },
+    { name: 'RGB Blue', hue: 218 },
+    { name: 'Cyan', hue: 188 },
+    { name: 'Magenta', hue: 316 },
+    { name: 'Amber', hue: 38 },
+  ];
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const useMorandi = Math.random() < 0.58;
+    const family = pickRandom(useMorandi ? morandiFamilies : vividFamilies);
+    const hueOffset = useMorandi
+      ? pickRandom([22, 32, 44, 56, 86, 128])
+      : pickRandom([30, 45, 60, 120, 180]);
+    const primaryHue = (family.hue + randomInt(-10, 10) + 360) % 360;
+    const secondaryHue = (primaryHue + hueOffset + randomInt(-8, 8) + 360) % 360;
+    const primary = useMorandi
+      ? hslToHex(primaryHue, randomInt(24, 42), randomInt(54, 68))
+      : hslToHex(primaryHue, randomInt(76, 94), randomInt(48, 60));
+    const secondary = useMorandi
+      ? hslToHex(secondaryHue, randomInt(22, 40), randomInt(52, 70))
+      : hslToHex(secondaryHue, randomInt(72, 92), randomInt(48, 62));
+
+    if (isPleasantColorPair(primary, secondary)) {
+      return {
+        name: `${family.name} ${String(index).padStart(2, '0')}`,
+        primary,
+        secondary,
+      };
+    }
+  }
+
+  const fallback = pickRandom([
+    { name: 'Soft Moss', primary: '#86a88f', secondary: '#d6a1aa' },
+    { name: 'RGB Glow', primary: '#00d26a', secondary: '#247cff' },
+    { name: 'Rose Cement', primary: '#c99aa3', secondary: '#9ba3ad' },
+    { name: 'Clean Signal', primary: '#ff2d55', secondary: '#00c2ff' },
+  ]);
+
+  return {
+    name: `${fallback.name} ${String(index).padStart(2, '0')}`,
+    primary: fallback.primary,
+    secondary: fallback.secondary,
+  };
+}
+
 function ColumnsIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -100,7 +270,352 @@ function ColumnsIcon() {
     </svg>
   );
 }
+interface LyricLine {
+  time: number;
+  endTime?: number;
+  text: string;
+}
 
+function vttTimeToSeconds(timeStr: string): number {
+  const parts = timeStr.trim().split(':');
+  if (parts.length === 3) {
+    const hours = parseInt(parts[0], 10);
+    const minutes = parseInt(parts[1], 10);
+    const secondsWithMs = parseFloat(parts[2]);
+    return hours * 3600 + minutes * 60 + secondsWithMs;
+  } else if (parts.length === 2) {
+    const minutes = parseInt(parts[0], 10);
+    const secondsWithMs = parseFloat(parts[1]);
+    return minutes * 60 + secondsWithMs;
+  }
+  return parseFloat(timeStr) || 0;
+}
+function formatSecondsToLrcTime(seconds: number): string {
+  if (seconds < 0) seconds = 0;
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  const ms = Math.floor((seconds % 1) * 100);
+  
+  const minStr = String(mins).padStart(2, '0');
+  const secStr = String(secs).padStart(2, '0');
+  const msStr = String(ms).padStart(2, '0');
+  
+  return `[${minStr}:${secStr}.${msStr}]`;
+}
+
+function cleanRenderableLyricText(text: string): string {
+  return text
+    .split('\n')
+    .map(line => line
+      .replace(/\[(?:intro|verse|pre[-\s]?chorus|chorus|bridge|outro|hook|refrain|interlude|instrumental|breakdown|drop|build|solo|spoken|final(?:\s+chorus)?|post[-\s]?chorus|prelude|ending|song\s+ends?)[^\]]*\]/gi, '')
+      .replace(/^(?:intro|verse|pre[-\s]?chorus|chorus|bridge|outro|hook|refrain|interlude|instrumental|breakdown|drop|build|solo|spoken|final(?:\s+chorus)?|post[-\s]?chorus|prelude|ending)\s*\d*\s*[:\-–—]?\s*/i, '')
+      .trim()
+    )
+    .filter(Boolean)
+    .join('\n');
+}
+
+function convertVttToLrc(vttText: string): string {
+  if (!vttText) return '';
+  const lines = vttText.split(/\r?\n/);
+  const cues: { startTime: number; endTime: number; lines: string[] }[] = [];
+  let currentCue: { startTime?: number; endTime?: number; lines: string[] } | null = null;
+  
+  const timeRangeRegex = /(\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})/;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) {
+      if (currentCue && currentCue.startTime !== undefined && currentCue.endTime !== undefined) {
+        cues.push(currentCue as any);
+        currentCue = null;
+      }
+      continue;
+    }
+    if (line.startsWith('WEBVTT')) {
+      continue;
+    }
+    const match = timeRangeRegex.exec(line);
+    if (match) {
+      if (currentCue) {
+        if (currentCue.startTime !== undefined && currentCue.endTime !== undefined) {
+          cues.push(currentCue as any);
+        }
+        currentCue = null;
+      }
+      currentCue = {
+        startTime: vttTimeToSeconds(match[1]),
+        endTime: vttTimeToSeconds(match[2]),
+        lines: []
+      };
+    } else {
+      let isCueId = false;
+      if (!currentCue) {
+        let nextHasArrow = false;
+        for (let j = i + 1; j < lines.length; j++) {
+          const nextLine = lines[j].trim();
+          if (!nextLine) continue;
+          if (nextLine.includes('-->')) {
+            nextHasArrow = true;
+          }
+          break;
+        }
+        if (nextHasArrow) {
+          isCueId = true;
+        }
+      }
+      if (!isCueId) {
+        if (currentCue) {
+          currentCue.lines.push(line);
+        }
+      }
+    }
+  }
+  if (currentCue && currentCue.startTime !== undefined && currentCue.endTime !== undefined) {
+    cues.push(currentCue as any);
+  }
+  const lrcLines: string[] = [];
+  for (const cue of cues) {
+    const n = cue.lines.length;
+    if (n === 0) continue;
+    
+    const duration = cue.endTime - cue.startTime;
+    for (let idx = 0; idx < n; idx++) {
+      const lineText = cleanRenderableLyricText(cue.lines[idx]);
+      if (!lineText) continue;
+      let lineTime = cue.startTime;
+      if (n > 1) {
+        lineTime = cue.startTime + (idx * duration) / n;
+      }
+      lrcLines.push(`${formatSecondsToLrcTime(lineTime)} ${lineText}`);
+    }
+  }
+  return lrcLines.join('\n');
+}
+
+function parseVttToLyricLines(vttText: string): LyricLine[] {
+  if (!vttText) return [];
+  const lines = vttText.split(/\r?\n/);
+  const cues: { startTime: number; endTime: number; lines: string[] }[] = [];
+  let currentCue: { startTime?: number; endTime?: number; lines: string[] } | null = null;
+  const timeRangeRegex = /(\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) {
+      if (currentCue?.startTime !== undefined && currentCue.endTime !== undefined) {
+        cues.push(currentCue as { startTime: number; endTime: number; lines: string[] });
+        currentCue = null;
+      }
+      continue;
+    }
+    if (line === 'WEBVTT' || line.startsWith('NOTE')) continue;
+
+    const match = timeRangeRegex.exec(line);
+    if (match) {
+      if (currentCue?.startTime !== undefined && currentCue.endTime !== undefined) {
+        cues.push(currentCue as { startTime: number; endTime: number; lines: string[] });
+      }
+      currentCue = {
+        startTime: vttTimeToSeconds(match[1]),
+        endTime: vttTimeToSeconds(match[2]),
+        lines: []
+      };
+      continue;
+    }
+
+    let nextHasArrow = false;
+    for (let j = i + 1; j < lines.length; j++) {
+      const nextLine = lines[j].trim();
+      if (!nextLine) continue;
+      nextHasArrow = nextLine.includes('-->');
+      break;
+    }
+    if (!currentCue && nextHasArrow) continue;
+
+    if (currentCue) {
+      currentCue.lines.push(line);
+    }
+  }
+
+  if (currentCue?.startTime !== undefined && currentCue.endTime !== undefined) {
+    cues.push(currentCue as { startTime: number; endTime: number; lines: string[] });
+  }
+
+  const lyricLines: LyricLine[] = [];
+  for (const cue of cues) {
+    const cleanedLines = cue.lines
+      .map(line => cleanRenderableLyricText(line))
+      .filter(Boolean);
+    if (cleanedLines.length === 0) continue;
+
+    const cueDuration = Math.max(0, cue.endTime - cue.startTime);
+    cleanedLines.forEach((text, idx) => {
+      const start = cleanedLines.length > 1
+        ? cue.startTime + (idx * cueDuration) / cleanedLines.length
+        : cue.startTime;
+      const end = cleanedLines.length > 1
+        ? cue.startTime + ((idx + 1) * cueDuration) / cleanedLines.length
+        : cue.endTime;
+      lyricLines.push({ time: start, endTime: end, text });
+    });
+  }
+
+  return lyricLines.sort((a, b) => a.time - b.time);
+}
+
+function mergeShortLyricLines(lines: LyricLine[]): LyricLine[] {
+  const sorted = [...lines].sort((a, b) => a.time - b.time);
+  const merged: LyricLine[] = [];
+  const minDisplayDuration = 2.0;
+  let i = 0;
+
+  while (i < sorted.length) {
+    const current = sorted[i];
+    let text = current.text;
+    let endTime = current.endTime;
+    let nextIdx = i + 1;
+
+    while (nextIdx < sorted.length && sorted[nextIdx].time - current.time < minDisplayDuration) {
+      text += `\n${sorted[nextIdx].text}`;
+      endTime = sorted[nextIdx].endTime;
+      nextIdx++;
+    }
+
+    merged.push({ time: current.time, endTime, text });
+    i = nextIdx;
+  }
+
+  return merged.map((line, idx) => ({
+    ...line,
+    endTime: line.endTime ?? merged[idx + 1]?.time
+  }));
+}
+// Parses standard [mm:ss.xx] or [mm:ss.xxx] LRC text, converting VTT automatically if passed
+function parseLrc(lrcText: string): LyricLine[] {
+  if (!lrcText) return [];
+  const cleanText = lrcText.trim();
+  if (cleanText.startsWith('WEBVTT') || cleanText.includes('-->')) {
+    return parseVttToLyricLines(lrcText);
+  }
+  const lines = lrcText.split('\n');
+  const result: LyricLine[] = [];
+  const timeRegex = /\[(\d{2}):(\d{2})\.(\d{2,3})\]/;
+  for (const line of lines) {
+    const cleanLine = line.trim();
+    if (!cleanLine) continue;
+    
+    const match = timeRegex.exec(cleanLine);
+    if (match) {
+      const minutes = parseInt(match[1], 10);
+      const seconds = parseInt(match[2], 10);
+      const msStr = match[3];
+      const milliseconds = parseInt(msStr, 10);
+      const msDivisor = Math.pow(10, msStr.length);
+      const time = minutes * 60 + seconds + milliseconds / msDivisor;
+      const text = cleanRenderableLyricText(cleanLine.replace(/\[\d{2}:\d{2}\.\d{2,3}\]/g, '').trim());
+      if (text) result.push({ time, text });
+    }
+  }
+  return mergeShortLyricLines(result);
+}
+// Generates a mock LRC with lines spaced evenly across the duration
+function generateMockLrc(rawLyrics: string | undefined | null, durationSec = 60): string {
+  if (!rawLyrics) {
+    return `[00:00.00] Instrumentals`;
+  }
+  // Strip bracket headers like [Verse 1], [Chorus]
+  const lines = rawLyrics
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith('[') && !line.endsWith(']'));
+  if (lines.length === 0) {
+   return `[00:00.00] Instrumentals`;
+  }
+  const interval = durationSec / (lines.length + 1);
+  return lines.map((line, idx) => {
+    const timeSec = (idx + 1) * interval;
+    const mins = Math.floor(timeSec / 60);
+    const secs = Math.floor(timeSec % 60);
+    const ms = Math.floor((timeSec % 1) * 100);
+    
+    const minStr = String(mins).padStart(2, '0');
+    const secStr = String(secs).padStart(2, '0');
+    const msStr = String(ms).padStart(2, '0');
+    
+    return `[${minStr}:${secStr}.${msStr}] ${line}`;
+  }).join('\n');
+}
+// Get the active lyric text based on time
+function getActiveLyricText(currentTime: number, parsedLyrics: LyricLine[], defaultText: string): string {
+  if (parsedLyrics.length === 0) return defaultText;
+  const active = parsedLyrics.find((line, idx) => {
+    const nextLine = parsedLyrics[idx + 1];
+    const endTime = line.endTime ?? nextLine?.time;
+    return currentTime >= line.time && (!endTime || currentTime < endTime);
+  });
+  return active ? active.text : '';
+}
+// Parse duration string (like "03:45" or raw seconds) to seconds
+function parseDurationToSeconds(durationStr: string | undefined | null): number {
+  if (!durationStr) return 60;
+  if (durationStr.includes(':')) {
+    const parts = durationStr.split(':');
+    if (parts.length === 2) {
+      return parseInt(parts[0], 10) * 60 + parseFloat(parts[1]);
+    }
+  }
+  const parsed = parseFloat(durationStr);
+  return isNaN(parsed) ? 60 : parsed;
+}
+// Shift all timestamps in standard [mm:ss.xx] LRC text by offsetSec
+function shiftLrcTimestamps(lrcText: string, offsetSec: number): string {
+  if (!lrcText) return '';
+  const timeRegex = /\[(\d{2}):(\d{2})\.(\d{2,3})\]/g;
+  return lrcText.replace(timeRegex, (match, minStr, secStr, csStr) => {
+    const minutes = parseInt(minStr, 10);
+    const seconds = parseInt(secStr, 10);
+    const cs = parseInt(csStr, 10);
+    const timeFactor = csStr.length === 2 ? 100 : 1000;
+    
+    let totalSec = minutes * 60 + seconds + cs / timeFactor;
+    totalSec = Math.max(0, totalSec + offsetSec);
+    
+    const newMin = Math.floor(totalSec / 60);
+    const newSec = Math.floor(totalSec % 60);
+    const newMs = Math.floor((totalSec % 1) * 100);
+    
+    const newMinStr = String(newMin).padStart(2, '0');
+    const newSecStr = String(newSec).padStart(2, '0');
+    const newMsStr = String(newMs).padStart(2, '0');
+    
+    return `[${newMinStr}:${newSecStr}.${newMsStr}]`;
+  });
+}
+
+function getProxiedVideoUrl(url: string): string {
+  if (!url || url.startsWith('blob:') || url.startsWith('data:') || url.startsWith('/')) return url;
+  try {
+    const parsed = new URL(url, window.location.href);
+    if (parsed.origin === window.location.origin) return url;
+  } catch {
+    return url;
+  }
+  return `/api/proxy/video?url=${encodeURIComponent(url)}`;
+}
+
+function drawCenteredMultilineText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  lineHeight: number
+): void {
+  const lines = text.split('\n').map(line => line.trim()).filter(Boolean);
+  const startY = y - ((lines.length - 1) * lineHeight) / 2;
+  lines.forEach((line, idx) => {
+    ctx.fillText(line, x, startY + idx * lineHeight);
+  });
+}
 export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen, onClose, song }) => {
   const { isMobile } = useResponsive();
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -111,6 +626,7 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
   const bgImageRef = useRef<HTMLImageElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const videoFileInputRef = useRef<HTMLInputElement>(null);
+  const recentColorPresetKeysRef = useRef<Set<string>>(new Set());
 
   // FFmpeg Refs
   const ffmpegRef = useRef<FFmpeg | null>(null);
@@ -139,6 +655,9 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
   const [pexelsPhotos, setPexelsPhotos] = useState<PexelsPhoto[]>([]);
   const [pexelsVideos, setPexelsVideos] = useState<PexelsVideo[]>([]);
   const [pexelsLoading, setPexelsLoading] = useState(false);
+  const [pexelsLoadingMore, setPexelsLoadingMore] = useState(false);
+  const [pexelsPage, setPexelsPage] = useState(1);
+  const [pexelsHasMore, setPexelsHasMore] = useState(false);
   const [pexelsApiKey, setPexelsApiKey] = useState<string>(() => localStorage.getItem('pexels_api_key') || '');
   const [showPexelsApiKeyInput, setShowPexelsApiKeyInput] = useState(false);
   const [pexelsError, setPexelsError] = useState<string | null>(null);
@@ -157,6 +676,7 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
     bgDim: 0.6,
     particleCount: 50
   });
+  const [visibleColorPresets, setVisibleColorPresets] = useState<ColorPreset[]>(COLOR_PRESETS);
 
   const [effects, setEffects] = useState<EffectConfig>({
     shake: true,
@@ -190,15 +710,131 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
     letterbox: 0.5
   });
 
+  const randomizeColorPresets = useCallback(() => {
+    const nextPresets: ColorPreset[] = [];
+    const currentBatchKeys = new Set<string>();
+    const recentKeys = recentColorPresetKeysRef.current;
+
+    for (let idx = 0; idx < COLOR_PRESETS.length; idx += 1) {
+      let selected: ColorPreset | null = null;
+
+      for (let attempt = 0; attempt < 36; attempt += 1) {
+        const candidate = createRandomColorPreset(idx + 1);
+        const key = colorPresetKey(candidate);
+        if (
+          !currentBatchKeys.has(key) &&
+          !recentKeys.has(key) &&
+          isDistinctFromPresets(candidate, nextPresets)
+        ) {
+          selected = candidate;
+          break;
+        }
+      }
+
+      if (!selected) {
+        for (let attempt = 0; attempt < 24; attempt += 1) {
+          const candidate = createRandomColorPreset(idx + 1);
+          const key = colorPresetKey(candidate);
+          if (!currentBatchKeys.has(key) && isDistinctFromPresets(candidate, nextPresets)) {
+            selected = candidate;
+            break;
+          }
+        }
+      }
+
+      if (selected) {
+        const key = colorPresetKey(selected);
+        currentBatchKeys.add(key);
+        nextPresets.push(selected);
+      }
+    }
+
+    currentBatchKeys.forEach(key => recentKeys.add(key));
+    while (recentKeys.size > COLOR_PRESETS.length * 4) {
+      const firstKey = recentKeys.values().next().value;
+      if (!firstKey) break;
+      recentKeys.delete(firstKey);
+    }
+
+    setVisibleColorPresets(nextPresets);
+  }, []);
+
   // Text Layers State
   const [textLayers, setTextLayers] = useState<TextLayer[]>([]);
+    // Synchronized LRC Subtitles
+  const [lrcText, setLrcText] = useState<string>('');
+  const [originalLrcText, setOriginalLrcText] = useState<string>('');
+  const [parsedLyrics, setParsedLyrics] = useState<LyricLine[]>([]);
+  const parsedLyricsRef = useRef<LyricLine[]>([]);
+  const [timeOffset, setTimeOffset] = useState<number>(0);
+  const shouldUseSyncedLyrics = Boolean(song?.generationParams?.getLrc);
+  useEffect(() => {
+    parsedLyricsRef.current = parsedLyrics;
+  }, [parsedLyrics]);
+  const handleLrcChange = (newVal: string) => {
+    const cleanText = newVal.trim();
+    if (cleanText.startsWith('WEBVTT') || cleanText.includes('-->')) {
+      const converted = convertVttToLrc(newVal);
+      setLrcText(converted);
+      setParsedLyrics(parseLrc(newVal));
+    } else {
+      setLrcText(newVal);
+      setParsedLyrics(parseLrc(newVal));
+    }
+  };
+  // Load actual LRC file on load.
+  useEffect(() => {
+    if (!song) return;
 
+    if (!shouldUseSyncedLyrics) {
+      setLrcText('');
+      setOriginalLrcText('');
+      setParsedLyrics([]);
+      return;
+    }
+    
+    if (song.audioUrl) {
+      // Attempt to load .lrc file next to the audio file
+      const lrcUrl = song.audioUrl.replace(/\.[^/.]+$/, '.lrc');
+      console.log('[LyricsLoader] Attempting to fetch lyric file from:', lrcUrl);
+      fetch(lrcUrl)
+        .then(res => {
+           console.log('[LyricsLoader] Fetch response status:', res.status, res.statusText);
+          if (res.ok) return res.text();
+          throw new Error(`Fetch failed with status ${res.status}: ${res.statusText}`);
+        })
+        .then(text => {
+          console.log('[LyricsLoader] Successfully retrieved lyrics file contents. Length:', text.length);
+          const cleanText = text.trim();
+          if (cleanText.startsWith('WEBVTT') || cleanText.includes('-->')) {
+             console.log('[LyricsLoader] Detected WebVTT format, converting...');
+            const converted = convertVttToLrc(text);
+            console.log('[LyricsLoader] Conversion complete. LRC preview:', converted.substring(0, 100));
+            setLrcText(converted);
+            setOriginalLrcText(converted);
+            setParsedLyrics(parseLrc(text));
+          } else {
+             console.log('[LyricsLoader] Detected standard LRC format');
+            setLrcText(text);
+            setOriginalLrcText(text);
+            setParsedLyrics(parseLrc(text));
+          }
+        })
+        .catch(err => {
+          console.error('[LyricsLoader] Error loading lyric file:', err);
+          console.log('[LyricsLoader] No synced LRC available, falling back to text layers');
+          setLrcText('');
+          setOriginalLrcText('');
+          setParsedLyrics([]);
+        });
+    }
+  }, [song, shouldUseSyncedLyrics]);
   // Init default text on load
   useEffect(() => {
     if (song) {
         setTextLayers([
-            { id: '1', text: song.title, x: 50, y: 85, size: 52, color: '#ffffff', font: 'Inter' },
-            { id: '2', text: song.style.toUpperCase(), x: 50, y: 92, size: 24, color: '#3b82f6', font: 'Inter' }
+            { id: '1', text: song.title || '', x: 50, y: 85, size: 52, color: '#ffffff', font: 'Inter' },
+            { id: '2', text: song.style?.toUpperCase() || '', x: 50, y: 92, size: 24, color: '#3b82f6', font: 'Inter' }
         ]);
     }
   }, [song]);
@@ -288,7 +924,7 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
 
     const video = document.createElement('video');
     video.crossOrigin = 'anonymous';
-    video.src = videoUrl;
+    video.src = getProxiedVideoUrl(videoUrl);
     video.loop = true;
     video.muted = true;
     video.playsInline = true;
@@ -303,6 +939,7 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
       console.error('Failed to load video:', videoUrl);
       bgVideoRef.current = null;
     };
+    video.load();
 
     return () => {
       video.pause();
@@ -345,6 +982,8 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
     setIsExporting(false);
     setExportProgress(0);
     setExportStage('idle');
+    setVisibleColorPresets(COLOR_PRESETS);
+    recentColorPresetKeysRef.current.clear();
 
     // Audio Setup
     const audio = new Audio();
@@ -502,7 +1141,7 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
     if (backgroundType === 'video' && videoUrl) {
       bgVideo = document.createElement('video');
       bgVideo.crossOrigin = 'anonymous';
-      bgVideo.src = videoUrl;
+      bgVideo.src = getProxiedVideoUrl(videoUrl);
       bgVideo.muted = true;
       bgVideo.playsInline = true;
       await new Promise<void>((resolve) => {
@@ -716,14 +1355,38 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
       ctx.shadowColor = 'black';
       ctx.textAlign = 'center';
 
-      currentTexts.forEach(layer => {
-        ctx.fillStyle = layer.color;
-        const dynamicSize = layer.id === '1' && currentConfig.preset === 'Minimal' ? layer.size * pulse : layer.size;
-        ctx.font = `bold ${dynamicSize}px ${layer.font}, sans-serif`;
-        const xPos = (layer.x / 100) * width;
-        const yPos = (layer.y / 100) * height;
-        ctx.fillText(layer.text, xPos, yPos);
-      });
+      // currentTexts.forEach(layer => {
+      //   ctx.fillStyle = layer.color;
+      //   const dynamicSize = layer.id === '1' && currentConfig.preset === 'Minimal' ? layer.size * pulse : layer.size;
+      //   ctx.font = `bold ${dynamicSize}px ${layer.font}, sans-serif`;
+      //   const xPos = (layer.x / 100) * width;
+      //   const yPos = (layer.y / 100) * height;
+      //   ctx.fillText(layer.text, xPos, yPos);
+      // });
+       // Draw Synchronized LRC Lyrics instead of static text layers
+      const activeText = shouldUseSyncedLyrics ? getActiveLyricText(time, parsedLyricsRef.current, '') : '';
+      if (activeText) {
+        ctx.fillStyle = '#ffffff';
+        const lyricSize = 44;
+        ctx.font = `bold ${lyricSize}px Inter, sans-serif`;
+        
+        ctx.shadowBlur = 12;
+        ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
+        
+        const xPos = width / 2;
+        const yPos = 0.88 * height; // Bottom center
+        
+        drawCenteredMultilineText(ctx, activeText, xPos, yPos, lyricSize * 1.15);
+        } else if (!shouldUseSyncedLyrics || parsedLyricsRef.current.length === 0) {
+        // Fallback: draw static text layers if no lyrics are active or empty
+        currentTexts.forEach(layer => {
+          ctx.fillStyle = layer.color;
+          ctx.shadowBlur = 10;
+          ctx.shadowColor = 'black';
+          ctx.font = `bold ${layer.size * (layer.id === '1' ? pulse : 1)}px ${layer.font}, sans-serif`;
+          ctx.fillText(layer.text, (layer.x / 100) * width, (layer.y / 100) * height);
+        });
+      }
 
       ctx.restore();
 
@@ -945,13 +1608,18 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
     }
   };
 
-  const searchPexels = async (query: string, type: 'photos' | 'videos') => {
-    setPexelsLoading(true);
+  const searchPexels = async (query: string, type: 'photos' | 'videos', page = 1, append = false) => {
+    if (append) {
+      setPexelsLoadingMore(true);
+    } else {
+      setPexelsLoading(true);
+    }
     setPexelsError(null);
     try {
+      const perPage = type === 'photos' ? 30 : 24;
       const endpoint = type === 'photos'
-        ? `/api/pexels/photos?query=${encodeURIComponent(query)}`
-        : `/api/pexels/videos?query=${encodeURIComponent(query)}`;
+        ? `/api/pexels/photos?query=${encodeURIComponent(query)}&page=${page}&per_page=${perPage}`
+        : `/api/pexels/videos?query=${encodeURIComponent(query)}&page=${page}&per_page=${perPage}`;
 
       const headers: HeadersInit = {};
       if (pexelsApiKey) {
@@ -972,16 +1640,27 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
       }
 
       if (type === 'photos') {
-        setPexelsPhotos(data.photos || []);
+        const nextPhotos = data.photos || [];
+        setPexelsPhotos(prev => append ? [...prev, ...nextPhotos] : nextPhotos);
+        setPexelsHasMore(Boolean(data.next_page) || nextPhotos.length >= perPage);
       } else {
-        setPexelsVideos(data.videos || []);
+        const nextVideos = data.videos || [];
+        setPexelsVideos(prev => append ? [...prev, ...nextVideos] : nextVideos);
+        setPexelsHasMore(Boolean(data.next_page) || nextVideos.length >= perPage);
       }
+      setPexelsPage(page);
     } catch (error) {
       console.error('Pexels search failed:', error);
       setPexelsError('Search failed. Please try again.');
     } finally {
       setPexelsLoading(false);
+      setPexelsLoadingMore(false);
     }
+  };
+
+  const loadMorePexels = () => {
+    if (pexelsLoading || pexelsLoadingMore || !pexelsHasMore) return;
+    searchPexels(pexelsQuery, pexelsTab, pexelsPage + 1, true);
   };
 
   const savePexelsApiKey = (key: string) => {
@@ -991,7 +1670,7 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
     setPexelsError(null);
     // Retry search with new key
     if (key) {
-      searchPexels(pexelsQuery, pexelsTab);
+      searchPexels(pexelsQuery, pexelsTab, 1, false);
     }
   };
 
@@ -1011,7 +1690,7 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
     const sdFile = video.video_files.find(f => f.quality === 'sd');
     const videoFile = hdFile || sdFile || video.video_files[0];
     if (videoFile) {
-      setVideoUrl(videoFile.link);
+      setVideoUrl(getProxiedVideoUrl(videoFile.link));
       setBackgroundType('video');
       setShowPexelsBrowser(false);
     }
@@ -1020,11 +1699,13 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
   const openPexelsBrowser = (target: 'background' | 'albumArt' = 'background', tab: 'photos' | 'videos' = 'photos') => {
     setPexelsTarget(target);
     setPexelsTab(target === 'albumArt' ? 'photos' : tab); // Album art is always photos
+    setPexelsQuery('');
+    setPexelsPhotos([]);
+    setPexelsVideos([]);
+    setPexelsPage(1);
+    setPexelsHasMore(false);
+    setPexelsError(null);
     setShowPexelsBrowser(true);
-    const searchTab = target === 'albumArt' ? 'photos' : tab;
-    if ((searchTab === 'photos' && pexelsPhotos.length === 0) || (searchTab === 'videos' && pexelsVideos.length === 0)) {
-      searchPexels(pexelsQuery, searchTab);
-    }
   };
 
   const handleAlbumArtUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -1173,22 +1854,44 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
         ctx.imageSmoothingEnabled = true;
     }
 
-    // --- 3. CUSTOM TEXT LAYERS ---
+    // --- 3. CUSTOM TEXT LAYERS (DYNAMIC SUBTITLES) ---
     ctx.shadowBlur = 10;
     ctx.shadowColor = 'black';
     ctx.textAlign = 'center';
 
-    currentTexts.forEach(layer => {
-        ctx.fillStyle = layer.color;
-        // Adjust font size by pulse for title-like layers if needed, here we do static or slight pulse
-        const dynamicSize = layer.id === '1' && currentConfig.preset === 'Minimal' ? layer.size * pulse : layer.size;
-        ctx.font = `bold ${dynamicSize}px ${layer.font}, sans-serif`;
+    // currentTexts.forEach(layer => {
+    //     ctx.fillStyle = layer.color;
+    //     // Adjust font size by pulse for title-like layers if needed, here we do static or slight pulse
+    //     const dynamicSize = layer.id === '1' && currentConfig.preset === 'Minimal' ? layer.size * pulse : layer.size;
+    //     ctx.font = `bold ${dynamicSize}px ${layer.font}, sans-serif`;
         
-        const xPos = (layer.x / 100) * width;
-        const yPos = (layer.y / 100) * height;
+    //     const xPos = (layer.x / 100) * width;
+    //     const yPos = (layer.y / 100) * height;
         
-        ctx.fillText(layer.text, xPos, yPos);
-    });
+    //     ctx.fillText(layer.text, xPos, yPos);
+    // });
+    const currentTime = audioRef.current ? audioRef.current.currentTime : 0;
+    const activeText = shouldUseSyncedLyrics ? getActiveLyricText(currentTime, parsedLyricsRef.current, '') : '';
+    if (activeText) {
+        ctx.fillStyle = '#ffffff';
+        const lyricSize = 44;
+        ctx.font = `bold ${lyricSize}px Inter, sans-serif`;
+        ctx.shadowBlur = 12;
+        ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
+        const xPos = width / 2;
+        const yPos = 0.88 * height; // Bottom center
+        
+        drawCenteredMultilineText(ctx, activeText, xPos, yPos, lyricSize * 1.15);
+        } else if (!shouldUseSyncedLyrics || parsedLyricsRef.current.length === 0) {
+        // Fallback: draw static text layers if no lyrics are active or empty
+        currentTexts.forEach(layer => {
+            ctx.fillStyle = layer.color;
+            ctx.shadowBlur = 10;
+            ctx.shadowColor = 'black';
+            ctx.font = `bold ${layer.size * (layer.id === '1' ? pulse : 1)}px ${layer.font}, sans-serif`;
+            ctx.fillText(layer.text, (layer.x / 100) * width, (layer.y / 100) * height);
+        });
+    }
 
     ctx.restore();
 
@@ -1759,7 +2462,8 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
                 {[
                     { id: 'presets', label: 'Presets', icon: <Grid size={14} /> },
                     { id: 'style', label: 'Style', icon: <Palette size={14} /> },
-                    { id: 'text', label: 'Text', icon: <Type size={14} /> },
+                    // { id: 'text', label: 'Text', icon: <Type size={14} /> },
+                    { id: 'text', label: shouldUseSyncedLyrics ? 'Lyrics' : 'Text', icon: <Type size={14} /> },
                     { id: 'effects', label: 'FX', icon: <Zap size={14} /> }
                 ].map(tab => (
                     <button 
@@ -1912,20 +2616,20 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
 
                          {/* Colors */}
                          <div className="space-y-3">
-                             <label className="text-xs font-bold text-zinc-500 uppercase">Color Presets</label>
+                             <div className="flex items-center justify-between">
+                                 <label className="text-xs font-bold text-zinc-500 uppercase">Color Presets</label>
+                                 <button
+                                     type="button"
+                                     onClick={randomizeColorPresets}
+                                     className="h-7 w-7 rounded-lg border border-white/10 bg-white/5 text-zinc-400 hover:bg-white/10 hover:text-white transition-colors flex items-center justify-center"
+                                     title="Generate random color presets"
+                                     aria-label="Generate random color presets"
+                                 >
+                                     <Shuffle size={13} />
+                                 </button>
+                             </div>
                              <div className="grid grid-cols-5 gap-2">
-                                 {[
-                                     { name: 'Neon Pink', primary: '#ec4899', secondary: '#8b5cf6' },
-                                     { name: 'Cyber Blue', primary: '#06b6d4', secondary: '#3b82f6' },
-                                     { name: 'Sunset', primary: '#f97316', secondary: '#eab308' },
-                                     { name: 'Matrix', primary: '#22c55e', secondary: '#10b981' },
-                                     { name: 'Fire', primary: '#ef4444', secondary: '#f97316' },
-                                     { name: 'Ocean', primary: '#0ea5e9', secondary: '#06b6d4' },
-                                     { name: 'Violet', primary: '#a855f7', secondary: '#ec4899' },
-                                     { name: 'Gold', primary: '#eab308', secondary: '#f59e0b' },
-                                     { name: 'Ice', primary: '#67e8f9', secondary: '#a5f3fc' },
-                                     { name: 'Mono', primary: '#ffffff', secondary: '#a1a1aa' },
-                                 ].map((preset) => (
+                                 {visibleColorPresets.map((preset) => (
                                      <button
                                          key={preset.name}
                                          onClick={() => setConfig({...config, primaryColor: preset.primary, secondaryColor: preset.secondary})}
@@ -2031,15 +2735,128 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
 
                 {/* TEXT TAB */}
                 {activeTab === 'text' && (
-                    <div className="space-y-4">
-                        <button 
+                    // <div className="space-y-4">
+                    //     <button 
+                    //         onClick={addTextLayer}
+                    //         className="w-full py-2 bg-pink-600 text-white rounded-lg flex items-center justify-center gap-2 text-xs font-bold hover:bg-pink-700"
+                       <div className="space-y-4 flex flex-col">
+                        {shouldUseSyncedLyrics ? (
+                          <>
+                        <div className="space-y-1">
+                            <label className="text-xs font-bold text-zinc-400 uppercase">Synchronized LRC Lyrics</label>
+                            <p className="text-[11px] text-zinc-500">
+                                Edit LRC timing in <code className="text-pink-500 font-mono">[mm:ss.xx]</code> format. Subtitles sync automatically in real time and are embedded in the output.
+                            </p>
+                        </div>
+                        
+                        <div className="w-full">
+                            <textarea
+                                value={lrcText}
+                                onChange={(e) => handleLrcChange(e.target.value)}
+                                className="w-full bg-black/40 border border-white/5 rounded-xl p-3 text-xs font-mono text-white focus:outline-none focus:border-pink-500 resize-y custom-scrollbar min-h-[250px]"
+                                placeholder="[00:00.00] Lyric line 1..."
+                            />
+                        </div>
+                        {/* Shift Timestamps Tool */}
+                        <div className="bg-black/20 p-3 rounded-lg border border-white/5 flex items-center justify-between gap-3">
+                            <div className="flex flex-col">
+                                <span className="text-[11px] text-zinc-400 font-bold">Shift Timestamps</span>
+                                <span className="text-[9px] text-zinc-500 flex items-center gap-1">
+                                    Offset all lines (e.g. <span className="text-pink-500 font-semibold">+17</span> or <span className="text-pink-500 font-semibold">-5</span> sec)
+                                </span>
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <input
+                                    type="number"
+                                    step="0.1"
+                                    value={timeOffset}
+                                    onChange={(e) => setTimeOffset(parseFloat(e.target.value) || 0)}
+                                    className="w-16 bg-zinc-800 rounded px-2 py-1 text-xs text-white border border-white/5 text-center focus:outline-none focus:border-pink-500"
+                                    placeholder="Secs"
+                                />
+                                <button
+                                    onClick={() => {
+                                        if (timeOffset !== 0) {
+                                            const shifted = shiftLrcTimestamps(lrcText, timeOffset);
+                                            handleLrcChange(shifted);
+                                            setTimeOffset(0);
+                                        }
+                                    }}
+                                    className="px-3 py-1 bg-pink-600 hover:bg-pink-700 text-white rounded text-xs font-bold transition-colors"
+                                >
+                                    Apply
+                                </button>
+                            </div>
+                        </div>
+                        <button
+                            onClick={() => {
+                                if (originalLrcText) {
+                                  handleLrcChange(originalLrcText);
+                                }
+                            }}
+                            disabled={!originalLrcText}
+                            className={`w-full py-2 border border-white/5 rounded-lg text-xs font-bold transition-colors ${
+                              originalLrcText
+                                ? 'bg-zinc-800 text-zinc-200 hover:bg-zinc-700'
+                                : 'bg-zinc-900/60 text-zinc-600 cursor-not-allowed'
+                            }`}
+                        >
+                            {/* <Plus size={14} /> Add Text Layer */}
+                            Reset to Original LRC
+                        </button>
+                          </>
+                        ) : (
+                          <>
+                        <button
                             onClick={addTextLayer}
                             className="w-full py-2 bg-pink-600 text-white rounded-lg flex items-center justify-center gap-2 text-xs font-bold hover:bg-pink-700"
                         >
                             <Plus size={14} /> Add Text Layer
                         </button>
-                        
+
                         <div className="space-y-3">
+                            {textLayers.map((layer, index) => (
+                                <div key={layer.id} className="bg-black/20 p-3 rounded-lg border border-white/5 space-y-3">
+                                    <div className="flex items-center justify-between">
+                                        <span className="text-xs font-bold text-zinc-500">Layer {index + 1}</span>
+                                        <button onClick={() => removeTextLayer(layer.id)} className="text-zinc-500 hover:text-red-500">
+                                            <Trash2 size={14} />
+                                        </button>
+                                    </div>
+                                    <input
+                                        type="text"
+                                        value={layer.text}
+                                        onChange={(e) => updateTextLayer(layer.id, { text: e.target.value })}
+                                        className="w-full bg-zinc-800 rounded px-2 py-1 text-xs text-white border border-white/5"
+                                        placeholder="Text content"
+                                    />
+                                    <div className="grid grid-cols-2 gap-2">
+                                        <div>
+                                            <label className="text-[10px] text-zinc-500 block mb-1">X Position</label>
+                                            <input type="range" min="0" max="100" value={layer.x} onChange={(e) => updateTextLayer(layer.id, { x: parseInt(e.target.value) })} className="w-full accent-pink-500 h-1 bg-zinc-700 rounded-lg appearance-none" />
+                                        </div>
+                                        <div>
+                                            <label className="text-[10px] text-zinc-500 block mb-1">Y Position</label>
+                                            <input type="range" min="0" max="100" value={layer.y} onChange={(e) => updateTextLayer(layer.id, { y: parseInt(e.target.value) })} className="w-full accent-pink-500 h-1 bg-zinc-700 rounded-lg appearance-none" />
+                                        </div>
+                                    </div>
+                                    <div className="flex gap-2">
+                                        <div className="flex-1">
+                                            <label className="text-[10px] text-zinc-500 block mb-1">Size</label>
+                                            <input type="number" value={layer.size} onChange={(e) => updateTextLayer(layer.id, { size: parseInt(e.target.value) })} className="w-full bg-zinc-800 rounded px-2 py-1 text-xs text-white border border-white/5" />
+                                        </div>
+                                        <div>
+                                            <label className="text-[10px] text-zinc-500 block mb-1">Color</label>
+                                            <input type="color" value={layer.color} onChange={(e) => updateTextLayer(layer.id, { color: e.target.value })} className="w-8 h-6 rounded cursor-pointer border-none bg-transparent" />
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                          </>
+                        )}
+                        
+                        {/* <div className="space-y-3">
                             {textLayers.map((layer, index) => (
                                 <div key={layer.id} className="bg-black/20 p-3 rounded-lg border border-white/5 space-y-3">
                                     <div className="flex items-center justify-between">
@@ -2077,7 +2894,7 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
                                     </div>
                                 </div>
                             ))}
-                        </div>
+                        </div> */}
                     </div>
                 )}
 
@@ -2300,13 +3117,13 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
               {pexelsTarget !== 'albumArt' && (
               <div className="flex gap-2">
                 <button
-                  onClick={() => { setPexelsTab('photos'); searchPexels(pexelsQuery, 'photos'); }}
+                  onClick={() => { setPexelsTab('photos'); searchPexels(pexelsQuery, 'photos', 1, false); }}
                   className={`px-4 py-2 rounded-lg text-sm font-bold flex items-center gap-2 ${pexelsTab === 'photos' ? 'bg-emerald-600 text-white' : 'bg-zinc-800 text-zinc-400'}`}
                 >
                   <ImageIcon size={14} /> Photos
                 </button>
                 <button
-                  onClick={() => { setPexelsTab('videos'); searchPexels(pexelsQuery, 'videos'); }}
+                  onClick={() => { setPexelsTab('videos'); searchPexels(pexelsQuery, 'videos', 1, false); }}
                   className={`px-4 py-2 rounded-lg text-sm font-bold flex items-center gap-2 ${pexelsTab === 'videos' ? 'bg-emerald-600 text-white' : 'bg-zinc-800 text-zinc-400'}`}
                 >
                   <Video size={14} /> Videos
@@ -2318,12 +3135,12 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
                   type="text"
                   value={pexelsQuery}
                   onChange={(e) => setPexelsQuery(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && searchPexels(pexelsQuery, pexelsTab)}
+                  onKeyDown={(e) => e.key === 'Enter' && searchPexels(pexelsQuery, pexelsTab, 1, false)}
                   placeholder="Search for backgrounds..."
                   className="flex-1 bg-zinc-800 rounded-lg px-4 py-2 text-sm text-white border border-white/10 placeholder-zinc-500"
                 />
                 <button
-                  onClick={() => searchPexels(pexelsQuery, pexelsTab)}
+                  onClick={() => searchPexels(pexelsQuery, pexelsTab, 1, false)}
                   disabled={pexelsLoading}
                   className="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 rounded-lg text-white font-bold text-sm flex items-center gap-2 disabled:opacity-50"
                 >
@@ -2336,7 +3153,7 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
                 {['abstract', 'nature', 'city', 'space', 'neon', 'particles', 'smoke', 'fire', 'water', 'technology'].map(tag => (
                   <button
                     key={tag}
-                    onClick={() => { setPexelsQuery(tag); searchPexels(tag, pexelsTab); }}
+                    onClick={() => { setPexelsQuery(tag); searchPexels(tag, pexelsTab, 1, false); }}
                     className="px-3 py-1 bg-zinc-800 hover:bg-zinc-700 rounded-full text-xs text-zinc-400 hover:text-white capitalize"
                   >
                     {tag}
@@ -2347,7 +3164,7 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
 
             {/* Results Grid */}
             <div className="flex-1 overflow-y-auto p-4">
-              {pexelsLoading ? (
+              {pexelsLoading && !pexelsLoadingMore ? (
                 <div className="flex items-center justify-center h-48">
                   <Loader2 size={32} className="animate-spin text-emerald-500" />
                 </div>
@@ -2397,6 +3214,18 @@ export const VideoGeneratorModal: React.FC<VideoGeneratorModalProps> = ({ isOpen
               )}
               {!pexelsLoading && pexelsVideos.length === 0 && pexelsTab === 'videos' && (
                 <p className="text-center text-zinc-500 py-8">No videos found. Try a different search term.</p>
+              )}
+              {!pexelsLoading && pexelsHasMore && (
+                <div className="flex justify-center pt-4">
+                  <button
+                    onClick={loadMorePexels}
+                    disabled={pexelsLoadingMore}
+                    className="px-4 py-2 rounded-lg bg-zinc-800 hover:bg-zinc-700 text-sm font-bold text-zinc-200 transition-colors disabled:opacity-60 disabled:cursor-not-allowed flex items-center gap-2"
+                  >
+                    {pexelsLoadingMore && <Loader2 size={14} className="animate-spin" />}
+                    {pexelsLoadingMore ? 'Loading...' : 'Load More'}
+                  </button>
+                </div>
               )}
             </div>
 

--- a/server/scripts/simple_generate.py
+++ b/server/scripts/simple_generate.py
@@ -10,9 +10,34 @@ import os
 import sys
 import time
 import torch
+import re
 
 # Get ACE-Step path from environment or use default
 ACESTEP_PATH = os.environ.get('ACESTEP_PATH', '/home/ambsd/Desktop/aceui/ACE-Step-1.5')
+
+# Load .env file from ACE-Step path if it exists to populate os.environ
+env_path = os.path.join(ACESTEP_PATH, '.env')
+if not os.path.exists(env_path):
+    env_path = os.path.join(ACESTEP_PATH, 'env')
+
+# Diagnostic logging for visibility in Node.js
+print(f"[simple_generate] ACESTEP_PATH: '{ACESTEP_PATH}'", file=sys.stderr)
+print(f"[simple_generate] Checked env_path: '{env_path}' (exists: {os.path.exists(env_path)})", file=sys.stderr)
+
+if os.path.exists(env_path):
+    try:
+        with open(env_path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith('#') and '=' in line:
+                    key, val = line.split('=', 1)
+                    key = key.strip()
+                    val = val.strip().strip('"').strip("'")
+                    if key not in os.environ:
+                        os.environ[key] = val
+        print(f"[simple_generate] Successfully loaded environment from {env_path}", file=sys.stderr)
+    except Exception as env_err:
+        print(f"Warning: failed to load config from {env_path}: {env_err}", file=sys.stderr)
 
 # Add ACE-Step to path
 sys.path.insert(0, ACESTEP_PATH)
@@ -25,24 +50,148 @@ from acestep.inference import GenerationParams, GenerationConfig, generate_music
 _handler = None
 _llm_handler = None
 
-def get_handlers():
+def get_handlers(dit_model=None, vae_checkpoint=None):
     global _handler, _llm_handler
     if _handler is None:
-        if torch.cuda.is_available():
-            device = "cuda"
-        elif torch.backends.mps.is_available():
-            device = "mps"
+        # Respect device setting from environment/.env if defined
+        env_device = os.environ.get('ACESTEP_DEVICE', 'auto').lower()
+        if env_device in ['cuda', 'cpu', 'mps', 'xpu']:
+            device = env_device
         else:
-            device = "cpu"
+            if torch.cuda.is_available():
+                device = "cuda"
+            elif torch.backends.mps.is_available():
+                device = "mps"
+            else:
+                device = "cpu"
+        
+        # Use frontend selected model, fallback to ACESTEP_CONFIG_PATH from .env, or default to "acestep-v15-turbo"
+        default_config = os.environ.get('ACESTEP_CONFIG_PATH', 'acestep-v15-turbo')
+        config_path = dit_model if (dit_model and dit_model.strip()) else default_config
+         # Use provided VAE, fallback to env var, or default to "official"
+        vae_val = vae_checkpoint if (vae_checkpoint and vae_checkpoint.strip()) else os.environ.get('ACESTEP_VAE_CHECKPOINT', 'official')
+        print(f"[simple_generate] Active configuration settings:", file=sys.stderr)
+        print(f"  - Device: {device}", file=sys.stderr)
+        print(f"  - DiT Model Config: {config_path}", file=sys.stderr)
+        print(f"  - VAE Model Override: {vae_val}", file=sys.stderr)
+        print(f"  - Torch Compile: {os.environ.get('ACESTEP_TORCH_COMPILE', 'default')}", file=sys.stderr)
+        
         _handler = AceStepHandler()
-        _handler.initialize_service(
-            project_root=ACESTEP_PATH,
-            config_path="acestep-v15-turbo",
-            device=device,
-            offload_to_cpu=True,  # For 12GB GPU
-        )
+        # _handler.initialize_service(
+        #     project_root=ACESTEP_PATH,
+        #     config_path=config_path,
+        #     device=device,
+        #     offload_to_cpu=True,  # For 12GB GPU
+        #     vae_checkpoint=vae_val,
+        # )
+         # Dynamically inspect parameter signature to support older versions of initialize_service
+        import inspect
+        init_sig = inspect.signature(_handler.initialize_service)
+        init_kwargs = {
+            "project_root": ACESTEP_PATH,
+            "config_path": config_path,
+            "device": device,
+            "offload_to_cpu": True,
+        }
+        if "vae_checkpoint" in init_sig.parameters:
+            init_kwargs["vae_checkpoint"] = vae_val
+            
+        _handler.initialize_service(**init_kwargs)
         _llm_handler = LLMHandler()  # Create but don't initialize (not enough VRAM)
     return _handler, _llm_handler
+def parse_lrc_to_subtitles(lrc_text: str, total_duration: float = None):
+    if not lrc_text or not lrc_text.strip():
+        return []
+    timestamp_pattern = r'\[(\d{2}):(\d{2})\.(\d{2,3})\]'
+    raw_entries = []
+    for line in lrc_text.strip().split('\n'):
+        line = line.strip()
+        if not line:
+            continue
+        timestamps = re.findall(timestamp_pattern, line)
+        if not timestamps:
+            continue
+        text = re.sub(timestamp_pattern, '', line).strip()
+        if not text:
+            continue
+        start_minutes, start_seconds, start_cs = timestamps[0]
+        cs = int(start_cs)
+        start_time = (
+            int(start_minutes) * 60 + int(start_seconds)
+            + (cs / 100.0 if len(start_cs) == 2 else cs / 1000.0)
+        )
+        end_time = None
+        if len(timestamps) >= 2:
+            end_min, end_sec, end_cs_str = timestamps[1]
+            cs_end = int(end_cs_str)
+            end_time = (
+                int(end_min) * 60 + int(end_sec)
+                + (cs_end / 100.0 if len(end_cs_str) == 2 else cs_end / 1000.0)
+            )
+        raw_entries.append({'start': start_time, 'explicit_end': end_time, 'text': text})
+    raw_entries.sort(key=lambda x: x['start'])
+    if not raw_entries:
+        return []
+    # Merge lines closer than MIN_DISPLAY_DURATION seconds
+    MIN_DISPLAY_DURATION = 2.0
+    merged_entries = []
+    i = 0
+    while i < len(raw_entries):
+        cur = raw_entries[i]
+        combined_text = cur['text']
+        combined_start = cur['start']
+        combined_explicit_end = cur['explicit_end']
+        next_idx = i + 1
+        while next_idx < len(raw_entries):
+            nxt = raw_entries[next_idx]
+            if nxt['start'] - combined_start < MIN_DISPLAY_DURATION:
+                combined_text += "\n" + nxt['text']
+                if nxt['explicit_end']:
+                    combined_explicit_end = nxt['explicit_end']
+                next_idx += 1
+            else:
+                break
+        merged_entries.append({
+            'start': combined_start,
+            'explicit_end': combined_explicit_end,
+            'text': combined_text,
+        })
+        i = next_idx
+    # Build final subtitles list
+    subtitles = []
+    for idx, entry in enumerate(merged_entries):
+        start = entry['start']
+        if entry['explicit_end'] is not None:
+            end = entry['explicit_end']
+        elif idx + 1 < len(merged_entries):
+            end = merged_entries[idx + 1]['start']
+        elif total_duration is not None and total_duration > start:
+            end = total_duration
+        else:
+            end = start + 5.0
+        if end <= start:
+            end = start + 3.0
+        subtitles.append({'text': entry['text'], 'timestamp': [start, end]})
+    return subtitles
+def format_vtt_timestamp(seconds: float) -> str:
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    millis = int((seconds % 1) * 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}.{millis:03d}"
+def convert_lrc_to_vtt_text(lrc_text: str, total_duration: float = None) -> str:
+    subtitles = parse_lrc_to_subtitles(lrc_text, total_duration=total_duration)
+    if not subtitles:
+        return ""
+    vtt_lines = ["WEBVTT", ""]
+    for i, sub in enumerate(subtitles):
+        vtt_lines.append(str(i + 1))
+        vtt_lines.append(
+            f"{format_vtt_timestamp(sub['timestamp'][0])} --> {format_vtt_timestamp(sub['timestamp'][1])}"
+        )
+        vtt_lines.append(sub['text'])
+        vtt_lines.append("")
+    return "\n".join(vtt_lines)
 
 def generate(
     # Basic parameters
@@ -90,12 +239,25 @@ def generate(
     use_adg: bool = False,
     cfg_interval_start: float = 0.0,
     cfg_interval_end: float = 1.0,
+    dcw_enabled: bool = True,
+    dcw_mode: str = "double",
+    dcw_scaler: float = None,
+    dcw_high_scaler: float = None,
+    dcw_wavelet: str = "haar",
 
     # Output
     output_dir: str = None,
+
+    # Model selection
+    dit_model: str = "",
+    vae_checkpoint: str = "official",
+    get_lrc: bool = False,
+    get_scores: bool = False,
+    score_scale: float = 0.5,
+
 ):
     """Generate music and return audio file paths."""
-    handler, llm_handler = get_handlers()
+    handler, llm_handler = get_handlers(dit_model=dit_model, vae_checkpoint=vae_checkpoint)
 
     # Initialize LLM handler if thinking is requested and it has not been initialized
     need_llm = (
@@ -125,7 +287,9 @@ def generate(
         lm_model_path = lm_model if (lm_model and lm_model.strip()) else None
         if not lm_model_path:
             # Auto-detect existing model on disk
-            if os.path.exists(os.path.join(checkpoint_dir, "acestep-5Hz-lm-1.7B")):
+            if os.path.exists(os.path.join(checkpoint_dir, "acestep-5Hz-lm-4B")):
+                lm_model_path = "acestep-5Hz-lm-4B"
+            elif os.path.exists(os.path.join(checkpoint_dir, "acestep-5Hz-lm-1.7B")):
                 lm_model_path = "acestep-5Hz-lm-1.7B"
             elif os.path.exists(os.path.join(checkpoint_dir, "acestep-5Hz-lm-0.6B")):
                 lm_model_path = "acestep-5Hz-lm-0.6B"
@@ -135,17 +299,17 @@ def generate(
         # Check if model exists, if not auto-download
         model_dir = os.path.join(checkpoint_dir, lm_model_path)
         if not os.path.exists(model_dir) or not os.listdir(model_dir):
-            print(f"[simple_generate] LLM Model {lm_model_path} not found, downloading...")
+            print(f"[simple_generate] LLM Model {lm_model_path} not found, downloading...", file=sys.stderr)
             try:
                 from acestep.model_downloader import download_submodel
                 from pathlib import Path
                 success, msg = download_submodel(lm_model_path, Path(checkpoint_dir))
                 if not success:
-                    print(f"Warning: failed to download submodel {lm_model_path}: {msg}")
+                    print(f"Warning: failed to download submodel {lm_model_path}: {msg}", file=sys.stderr)
             except Exception as download_err:
-                print(f"Warning: could not download LLM model: {download_err}")
+                print(f"Warning: could not download LLM model: {download_err}", file=sys.stderr)
 
-        print(f"[simple_generate] Initializing LLMHandler with model '{lm_model_path}' on device '{device}'...")
+        print(f"[simple_generate] Initializing LLMHandler with model '{lm_model_path}' on device '{device}'...", file=sys.stderr)
         status, success = llm_handler.initialize(
             checkpoint_dir=checkpoint_dir,
             lm_model_path=lm_model_path,
@@ -161,50 +325,99 @@ def generate(
     os.makedirs(output_dir, exist_ok=True)
 
     # Build generation params
-    params = GenerationParams(
-        # Basic
-        task_type=task_type,
-        caption=prompt,
-        lyrics=lyrics if lyrics and not instrumental else "",
-        instrumental=instrumental,
-        duration=float(duration) if duration > 0 else -1.0,
-        bpm=bpm if bpm > 0 else None,
-        keyscale=key_scale if key_scale else "",
-        timesignature=time_signature if time_signature else "",
-        vocal_language=vocal_language if vocal_language else "auto",
+    # Build generation params — dynamically filter arguments to support older versions of GenerationParams
+    import inspect
+    gp_sig = inspect.signature(GenerationParams)
+    gp_kwargs = {
+        # # Basic
+        # task_type=task_type,
+        # caption=prompt,
+        # lyrics=lyrics if lyrics and not instrumental else "",
+        # instrumental=instrumental,
+        # duration=float(duration) if duration > 0 else -1.0,
+        # bpm=bpm if bpm > 0 else None,
+        # keyscale=key_scale if key_scale else "",
+        # timesignature=time_signature if time_signature else "",
+        # vocal_language=vocal_language if vocal_language else "auto",
+        "task_type": task_type,
+        "caption": prompt,
+        "lyrics": lyrics if lyrics and not instrumental else "",
+        "instrumental": instrumental,
+        "duration": float(duration) if duration > 0 else -1.0,
+        "bpm": bpm if bpm > 0 else None,
+        "keyscale": key_scale if key_scale else "",
+        "timesignature": time_signature if time_signature else "",
+        "vocal_language": vocal_language if vocal_language else "auto",
+
 
         # Generation
-        inference_steps=infer_steps,
-        guidance_scale=guidance_scale,
-        seed=seed if seed >= 0 else -1,
-        shift=shift,
+        # inference_steps=infer_steps,
+        # guidance_scale=guidance_scale,
+        # seed=seed if seed >= 0 else -1,
+        # shift=shift,
+        "inference_steps": infer_steps,
+        "guidance_scale": guidance_scale,
+        "seed": seed if seed >= 0 else -1,
+        "shift": shift,
 
         # Task-specific
-        reference_audio=reference_audio if reference_audio else None,
-        src_audio=src_audio if src_audio else None,
-        audio_codes=audio_codes if audio_codes else "",
-        repainting_start=repainting_start,
-        repainting_end=repainting_end,
-        audio_cover_strength=audio_cover_strength,
-        instruction=instruction if instruction else "Fill the audio semantic mask based on the given conditions:",
+        # reference_audio=reference_audio if reference_audio else None,
+        # src_audio=src_audio if src_audio else None,
+        # audio_codes=audio_codes if audio_codes else "",
+        # repainting_start=repainting_start,
+        # repainting_end=repainting_end,
+        # audio_cover_strength=audio_cover_strength,
+        # instruction=instruction if instruction else "Fill the audio semantic mask based on the given conditions:",
+        "reference_audio": reference_audio if reference_audio else None,
+        "src_audio": src_audio if src_audio else None,
+        "audio_codes": audio_codes if audio_codes else "",
+        "repainting_start": repainting_start,
+        "repainting_end": repainting_end,
+        "audio_cover_strength": audio_cover_strength,
+        "instruction": instruction if instruction else "Fill the audio semantic mask based on the given conditions:",
 
         # LM/CoT
-        thinking=thinking,
-        lm_temperature=lm_temperature,
-        lm_cfg_scale=lm_cfg_scale,
-        lm_top_k=lm_top_k,
-        lm_top_p=lm_top_p,
-        lm_negative_prompt=lm_negative_prompt if lm_negative_prompt else "NO USER INPUT",
-        use_cot_metas=use_cot_metas,
-        use_cot_caption=use_cot_caption,
-        use_cot_language=use_cot_language,
+        # thinking=thinking,
+        # lm_temperature=lm_temperature,
+        # lm_cfg_scale=lm_cfg_scale,
+        # lm_top_k=lm_top_k,
+        # lm_top_p=lm_top_p,
+        # lm_negative_prompt=lm_negative_prompt if lm_negative_prompt else "NO USER INPUT",
+        # use_cot_metas=use_cot_metas,
+        # use_cot_caption=use_cot_caption,
+        # use_cot_language=use_cot_language,
+        "thinking": thinking,
+        "lm_temperature": lm_temperature,
+        "lm_cfg_scale": lm_cfg_scale,
+        "lm_top_k": lm_top_k,
+        "lm_top_p": lm_top_p,
+        "lm_negative_prompt": lm_negative_prompt if lm_negative_prompt else "NO USER INPUT",
+        "use_cot_metas": use_cot_metas,
+        "use_cot_caption": use_cot_caption,
+        "use_cot_language": use_cot_language,
 
         # Advanced
-        use_adg=use_adg,
-        cfg_interval_start=cfg_interval_start,
-        cfg_interval_end=cfg_interval_end,
-    )
-
+        # use_adg=use_adg,
+        # cfg_interval_start=cfg_interval_start,
+        # cfg_interval_end=cfg_interval_end,
+        # dcw_enabled=dcw_enabled,
+        # dcw_mode=dcw_mode,
+        # dcw_scaler=dcw_scaler,
+        # dcw_high_scaler=dcw_high_scaler,
+        # dcw_wavelet=dcw_wavelet,
+        "use_adg": use_adg,
+        "cfg_interval_start": cfg_interval_start,
+        "cfg_interval_end": cfg_interval_end,
+        "dcw_enabled": dcw_enabled,
+        "dcw_mode": dcw_mode,
+        "dcw_scaler": dcw_scaler,
+        "dcw_high_scaler": dcw_high_scaler,
+        "dcw_wavelet": dcw_wavelet,
+    # )
+    }
+    # Dynamic filtering: only pass parameters that exist in this version of GenerationParams
+    gp_kwargs = {k: v for k, v in gp_kwargs.items() if k in gp_sig.parameters}
+    params = GenerationParams(**gp_kwargs)
     # Build generation config
     config = GenerationConfig(
         batch_size=batch_size,
@@ -218,17 +431,198 @@ def generate(
 
     # Extract audio paths from result
     audio_paths = []
+    scores = []
     if result.audios:
-        for audio in result.audios:
+        # for audio in result.audios:
+        for idx0, audio in enumerate(result.audios):
             if isinstance(audio, dict) and audio.get("path"):
-                audio_paths.append(audio["path"])
+                # audio_paths.append(audio["path"])
+                audio_path = audio["path"]
+                audio_paths.append(audio_path)
+                
+                if get_lrc:
+                    try:
+                        # Extract intermediate tensors from extra_outputs
+                        extra_outputs = result.extra_outputs or {}
+                        pred_latents = extra_outputs.get("pred_latents")
+                        encoder_hidden_states = extra_outputs.get("encoder_hidden_states")
+                        encoder_attention_mask = extra_outputs.get("encoder_attention_mask")
+                        context_latents = extra_outputs.get("context_latents")
+                        lyric_token_idss = extra_outputs.get("lyric_token_idss")
+                        
+                        if all(x is not None for x in [pred_latents, encoder_hidden_states, encoder_attention_mask, context_latents, lyric_token_idss]):
+                            if idx0 < pred_latents.shape[0]:
+                                audio_duration = pred_latents.shape[1] / 25.0
+                                
+                                lrc_res = handler.get_lyric_timestamp(
+                                    pred_latent=pred_latents[idx0:idx0 + 1],
+                                    encoder_hidden_states=encoder_hidden_states[idx0:idx0 + 1],
+                                    encoder_attention_mask=encoder_attention_mask[idx0:idx0 + 1],
+                                    context_latents=context_latents[idx0:idx0 + 1],
+                                    lyric_token_ids=lyric_token_idss[idx0:idx0 + 1],
+                                    total_duration_seconds=float(audio_duration),
+                                    vocal_language=vocal_language or "en",
+                                    inference_steps=int(infer_steps),
+                                    seed=42,
+                                )
+                                
+                                if lrc_res.get("success") and lrc_res.get("lrc_text"):
+                                    lrc_text = lrc_res["lrc_text"]
+                                     # Convert to WebVTT format using the exact Gradio post-processing algorithm
+                                    vtt_text = convert_lrc_to_vtt_text(lrc_text, total_duration=float(audio_duration))
+                                    vtt_path = os.path.splitext(audio_path)[0] + ".vtt"
+                                    with open(vtt_path, "w", encoding="utf-8") as f_vtt:
+                                        f_vtt.write(vtt_text)
+                                    print(f"[simple_generate] Generated VTT file: {vtt_path}", file=sys.stderr)
+                                else:
+                                    print(f"[simple_generate] get_lyric_timestamp failed: {lrc_res.get('error', 'unknown error')}", file=sys.stderr)
+                        else:
+                            print("[simple_generate] Missing intermediate tensors in extra_outputs, cannot generate LRC", file=sys.stderr)
+                    except Exception as lrc_err:
+                        print(f"[simple_generate] Error generating LRC for sample {idx0}: {lrc_err}", file=sys.stderr)
+
+                if get_scores:
+                    score_text = calculate_python_fallback_score(
+                        handler=handler,
+                        llm_handler=llm_handler,
+                        result=result,
+                        sample_idx=idx0,
+                        prompt=prompt,
+                        lyrics=lyrics if lyrics and not instrumental else "",
+                        bpm=bpm if bpm > 0 else None,
+                        key_scale=key_scale,
+                        time_signature=time_signature,
+                        audio_duration=duration,
+                        vocal_language=vocal_language or "en",
+                        inference_steps=infer_steps,
+                        score_scale=score_scale,
+                    )
+                    scores.append(score_text)
 
     return {
         "success": True,
         "audio_paths": audio_paths,
+        "scores": scores,
         "elapsed_seconds": elapsed,
         "output_dir": output_dir,
     }
+
+def calculate_python_fallback_score(
+    handler,
+    llm_handler,
+    result,
+    sample_idx: int,
+    prompt: str,
+    lyrics: str,
+    bpm,
+    key_scale: str,
+    time_signature: str,
+    audio_duration,
+    vocal_language: str,
+    inference_steps: int,
+    score_scale: float,
+):
+    """Calculate the scorer payload available in Python fallback mode.
+
+    The fallback path usually bypasses the LM audio-code stage, so PMI/global
+    quality scoring is often unavailable. When intermediate tensors are present,
+    ACE-Step can still calculate lyric alignment scores from cross-attention.
+    """
+    try:
+        pmi_report = ""
+        pmi_note = ""
+        audio_codes_str = ""
+        if result.audios and sample_idx < len(result.audios):
+            audio_params = result.audios[sample_idx].get("params", {}) if isinstance(result.audios[sample_idx], dict) else {}
+            audio_codes_str = str(audio_params.get("audio_codes", "") or "").strip()
+
+        if audio_codes_str and getattr(llm_handler, "llm_initialized", False):
+            try:
+                from acestep.core.scoring.lm_score import calculate_pmi_score_per_condition
+
+                metadata = {}
+                if bpm is not None:
+                    metadata["bpm"] = int(bpm)
+                if prompt:
+                    metadata["caption"] = prompt
+                if audio_duration and float(audio_duration) > 0:
+                    metadata["duration"] = int(float(audio_duration))
+                if key_scale:
+                    metadata["keyscale"] = key_scale
+                if vocal_language:
+                    metadata["language"] = vocal_language
+                if time_signature:
+                    metadata["timesignature"] = time_signature
+
+                scores_per_condition, global_score, pmi_status = calculate_pmi_score_per_condition(
+                    llm_handler=llm_handler,
+                    audio_codes=audio_codes_str,
+                    caption=prompt or "",
+                    lyrics=lyrics or "",
+                    metadata=metadata,
+                    temperature=1.0,
+                    topk=10,
+                    score_scale=score_scale,
+                )
+
+                if scores_per_condition:
+                    condition_lines = "\n".join(
+                        f"{name}: {val:.4f}" for name, val in sorted(scores_per_condition.items())
+                    )
+                    pmi_report = (
+                        f"Global Quality Score: {global_score:.4f}\n"
+                        f"Per-condition scores:\n{condition_lines}\n\n"
+                    )
+                elif pmi_status:
+                    pmi_note = f"Global PMI quality score was not available: {pmi_status}"
+            except Exception as pmi_err:
+                pmi_note = f"Global PMI quality score could not be calculated: {pmi_err}"
+        elif audio_codes_str:
+            pmi_note = "Global PMI quality score was not calculated because the LLM scorer was not initialized."
+        else:
+            pmi_note = "Global PMI quality score is unavailable because no LM audio codes were saved for this sample."
+
+        if not lyrics or not lyrics.strip():
+            return (pmi_report + (pmi_note if pmi_note else "No lyric scoring data available for instrumental or empty-lyric generation.")).strip()
+
+        extra_outputs = result.extra_outputs or {}
+        pred_latents = extra_outputs.get("pred_latents")
+        encoder_hidden_states = extra_outputs.get("encoder_hidden_states")
+        encoder_attention_mask = extra_outputs.get("encoder_attention_mask")
+        context_latents = extra_outputs.get("context_latents")
+        lyric_token_idss = extra_outputs.get("lyric_token_idss")
+
+        required = [pred_latents, encoder_hidden_states, encoder_attention_mask, context_latents, lyric_token_idss]
+        if not all(x is not None for x in required):
+            return "Score requested, but intermediate alignment tensors were not returned by ACE-Step."
+        if sample_idx >= pred_latents.shape[0]:
+            return "Score requested, but this sample index was not found in ACE-Step tensors."
+
+        align_result = handler.get_lyric_score(
+            pred_latent=pred_latents[sample_idx:sample_idx + 1],
+            encoder_hidden_states=encoder_hidden_states[sample_idx:sample_idx + 1],
+            encoder_attention_mask=encoder_attention_mask[sample_idx:sample_idx + 1],
+            context_latents=context_latents[sample_idx:sample_idx + 1],
+            lyric_token_ids=lyric_token_idss[sample_idx:sample_idx + 1],
+            vocal_language=vocal_language or "en",
+            inference_steps=int(inference_steps),
+            seed=42,
+        )
+
+        if not align_result.get("success"):
+            return f"Alignment Score Failed: {align_result.get('error', 'Unknown error')}"
+
+        lm_align = float(align_result.get("lm_score", 0.0))
+        dit_align = float(align_result.get("dit_score", 0.0))
+        return (
+            pmi_report +
+            "Lyric Alignment Scores\n"
+            f"LM lyrics alignment score: {lm_align:.4f}\n"
+            f"DiT lyrics alignment score: {dit_align:.4f}"
+            + (f"\n\n{pmi_note}" if pmi_note else "")
+        ).strip()
+    except Exception as score_err:
+        return f"Score calculation error: {score_err}"
 
 def main():
     parser = argparse.ArgumentParser(description="Generate music with ACE-Step")
@@ -275,16 +669,23 @@ def main():
     parser.add_argument("--no-cot-language", action="store_true", help="Disable CoT for language")
     parser.add_argument("--lm-model", type=str, default="", help="LLM model path or name")
     parser.add_argument("--lm-backend", type=str, default="pt", choices=["pt", "vllm", "mlx", "auto"], help="LLM backend")
-
+    parser.add_argument("--dit-model", type=str, default="", help="DiT model path or name")
+    parser.add_argument("--vae-checkpoint", type=str, default="official", help="VAE checkpoint path or name")
     # Advanced parameters
     parser.add_argument("--use-adg", action="store_true", help="Use Adaptive Dual Guidance")
     parser.add_argument("--cfg-interval-start", type=float, default=0.0, help="CFG interval start")
     parser.add_argument("--cfg-interval-end", type=float, default=1.0, help="CFG interval end")
-
+    parser.add_argument("--no-dcw", action="store_true", help="Disable Dual Conditioning Wavelet")
+    parser.add_argument("--dcw-mode", type=str, default="double", choices=["double", "single", "none"], help="DCW conditioning mode")
+    parser.add_argument("--dcw-scaler", type=float, default=None, help="DCW scaler")
+    parser.add_argument("--dcw-high-scaler", type=float, default=None, help="DCW high scaler")
+    parser.add_argument("--dcw-wavelet", type=str, default="haar", help="DCW wavelet base")
     # Output
     parser.add_argument("--output-dir", type=str, default=None, help="Output directory")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
-
+    parser.add_argument("--get-lrc", action="store_true", help="Generate LRC timing files")
+    parser.add_argument("--get-scores", action="store_true", help="Generate score payloads")
+    parser.add_argument("--score-scale", type=float, default=0.5, help="Score sensitivity")
     args = parser.parse_args()
 
     try:
@@ -334,9 +735,20 @@ def main():
             use_adg=args.use_adg,
             cfg_interval_start=args.cfg_interval_start,
             cfg_interval_end=args.cfg_interval_end,
-
+            dcw_enabled=not args.no_dcw,
+            dcw_mode=args.dcw_mode,
+            dcw_scaler=args.dcw_scaler,
+            dcw_high_scaler=args.dcw_high_scaler,
+            dcw_wavelet=args.dcw_wavelet,
             # Output
             output_dir=args.output_dir,
+
+            # Model selection
+            dit_model=args.dit_model,
+            vae_checkpoint=args.vae_checkpoint,
+            get_lrc=args.get_lrc,
+            get_scores=args.get_scores,
+            score_scale=args.score_scale,
         )
 
         if args.json:

--- a/server/scripts/simple_generate.py
+++ b/server/scripts/simple_generate.py
@@ -83,6 +83,8 @@ def generate(
     use_cot_metas: bool = True,
     use_cot_caption: bool = True,
     use_cot_language: bool = True,
+    lm_model: str = "",
+    lm_backend: str = "pt",
 
     # Advanced parameters
     use_adg: bool = False,
@@ -94,6 +96,65 @@ def generate(
 ):
     """Generate music and return audio file paths."""
     handler, llm_handler = get_handlers()
+
+    # Initialize LLM handler if thinking is requested and it has not been initialized
+    need_llm = (
+        thinking
+        or use_cot_metas
+        or use_cot_caption
+        or use_cot_language
+    )
+
+    if need_llm and not llm_handler.llm_initialized:
+        checkpoint_dir = os.path.join(ACESTEP_PATH, "checkpoints")
+        
+        # Determine backend
+        backend = lm_backend or "pt"
+        if backend == "auto":
+            backend = "pt"
+            
+        # Resolve device
+        if torch.cuda.is_available():
+            device = "cuda"
+        elif torch.backends.mps.is_available():
+            device = "mps"
+        else:
+            device = "cpu"
+
+        # Determine model path
+        lm_model_path = lm_model if (lm_model and lm_model.strip()) else None
+        if not lm_model_path:
+            # Auto-detect existing model on disk
+            if os.path.exists(os.path.join(checkpoint_dir, "acestep-5Hz-lm-1.7B")):
+                lm_model_path = "acestep-5Hz-lm-1.7B"
+            elif os.path.exists(os.path.join(checkpoint_dir, "acestep-5Hz-lm-0.6B")):
+                lm_model_path = "acestep-5Hz-lm-0.6B"
+            else:
+                lm_model_path = "acestep-5Hz-lm-0.6B"  # Default fallback
+
+        # Check if model exists, if not auto-download
+        model_dir = os.path.join(checkpoint_dir, lm_model_path)
+        if not os.path.exists(model_dir) or not os.listdir(model_dir):
+            print(f"[simple_generate] LLM Model {lm_model_path} not found, downloading...")
+            try:
+                from acestep.model_downloader import download_submodel
+                from pathlib import Path
+                success, msg = download_submodel(lm_model_path, Path(checkpoint_dir))
+                if not success:
+                    print(f"Warning: failed to download submodel {lm_model_path}: {msg}")
+            except Exception as download_err:
+                print(f"Warning: could not download LLM model: {download_err}")
+
+        print(f"[simple_generate] Initializing LLMHandler with model '{lm_model_path}' on device '{device}'...")
+        status, success = llm_handler.initialize(
+            checkpoint_dir=checkpoint_dir,
+            lm_model_path=lm_model_path,
+            backend=backend,
+            device=device,
+            offload_to_cpu=True,
+        )
+        if not success:
+            raise RuntimeError(f"Failed to initialize LLM: {status}")
 
     if output_dir is None:
         output_dir = os.path.join(ACESTEP_PATH, "output")
@@ -212,6 +273,8 @@ def main():
     parser.add_argument("--no-cot-metas", action="store_true", help="Disable CoT for metadata")
     parser.add_argument("--no-cot-caption", action="store_true", help="Disable CoT for caption")
     parser.add_argument("--no-cot-language", action="store_true", help="Disable CoT for language")
+    parser.add_argument("--lm-model", type=str, default="", help="LLM model path or name")
+    parser.add_argument("--lm-backend", type=str, default="pt", choices=["pt", "vllm", "mlx", "auto"], help="LLM backend")
 
     # Advanced parameters
     parser.add_argument("--use-adg", action="store_true", help="Use Adaptive Dual Guidance")
@@ -264,6 +327,8 @@ def main():
             use_cot_metas=not args.no_cot_metas,
             use_cot_caption=not args.no_cot_caption,
             use_cot_language=not args.no_cot_language,
+            lm_model=args.lm_model,
+            lm_backend=args.lm_backend,
 
             # Advanced
             use_adg=args.use_adg,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -251,9 +251,38 @@ app.get('/api/proxy/image', async (req, res) => {
   }
 });
 
+// Video proxy for CORS-safe canvas rendering
+app.get('/api/proxy/video', async (req, res) => {
+  const url = req.query.url as string;
+  if (!url) {
+    res.status(400).json({ error: 'URL required' });
+    return;
+  }
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      res.status(response.status).json({ error: 'Failed to fetch video' });
+      return;
+    }
+
+    const contentType = response.headers.get('content-type') || 'video/mp4';
+    const buffer = await response.arrayBuffer();
+
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'public, max-age=86400');
+    res.send(Buffer.from(buffer));
+  } catch (error) {
+    console.error('Video proxy error:', error);
+    res.status(500).json({ error: 'Failed to proxy video' });
+  }
+});
+
 // Pexels API proxy - accepts API key from header or uses server config
 app.get('/api/pexels/photos', async (req, res) => {
   const query = req.query.query as string;
+  const page = Math.max(1, Math.min(100, Number(req.query.page) || 1));
+  const perPage = Math.max(1, Math.min(40, Number(req.query.per_page) || 30));
   if (!query) {
     res.status(400).json({ error: 'Query required' });
     return;
@@ -269,7 +298,7 @@ app.get('/api/pexels/photos', async (req, res) => {
 
   try {
     const response = await fetch(
-      `https://api.pexels.com/v1/search?query=${encodeURIComponent(query)}&per_page=20&orientation=landscape`,
+      `https://api.pexels.com/v1/search?query=${encodeURIComponent(query)}&per_page=${perPage}&page=${page}&orientation=landscape`,
       { headers: { Authorization: apiKey } }
     );
 
@@ -292,6 +321,8 @@ app.get('/api/pexels/photos', async (req, res) => {
 
 app.get('/api/pexels/videos', async (req, res) => {
   const query = req.query.query as string;
+  const page = Math.max(1, Math.min(100, Number(req.query.page) || 1));
+  const perPage = Math.max(1, Math.min(40, Number(req.query.per_page) || 24));
   if (!query) {
     res.status(400).json({ error: 'Query required' });
     return;
@@ -307,7 +338,7 @@ app.get('/api/pexels/videos', async (req, res) => {
 
   try {
     const response = await fetch(
-      `https://api.pexels.com/videos/search?query=${encodeURIComponent(query)}&per_page=15&orientation=landscape`,
+      `https://api.pexels.com/videos/search?query=${encodeURIComponent(query)}&per_page=${perPage}&page=${page}&orientation=landscape`,
       { headers: { Authorization: apiKey } }
     );
 

--- a/server/src/routes/generate.ts
+++ b/server/src/routes/generate.ts
@@ -2,6 +2,7 @@ import { Router, Response } from 'express';
 import multer from 'multer';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { readFile } from 'fs/promises';
 import { pool } from '../db/pool.js';
 import { generateUUID } from '../db/sqlite.js';
 import { config } from '../config/index.js';
@@ -17,9 +18,13 @@ import {
   getJobRawResponse,
   downloadAudioToBuffer,
   resolvePythonPath,
+  resolveAceStepPath,
 } from '../services/acestep.js';
 import { getStorageProvider } from '../services/storage/factory.js';
-
+import type { StorageProvider } from '../services/storage/index.js';
+// my acestep path
+// process.env.ACESTEP_PATH = 'D:\\ACE1.5';
+// process.env.PYTHON_PATH = 'D:\\ACE1.5\\.venv\\Scripts\\python.exe';
 const router = Router();
 
 // Auto-generate a song title from lyrics or style when none is provided
@@ -44,6 +49,49 @@ function autoTitle(params: { title?: string; lyrics?: string; instrumental?: boo
   }
 
   return 'Untitled';
+}
+
+function replaceExtension(filePath: string, ext: string): string {
+  return filePath.replace(/\.[^/.]+$/, ext);
+}
+
+async function readGeneratedCompanionFile(fileUrl: string): Promise<Buffer | null> {
+  try {
+    if (fileUrl.startsWith('/audio/')) {
+      const localPath = path.join(config.storage.audioDir, fileUrl.replace('/audio/', ''));
+      return await readFile(localPath);
+    }
+
+    const { buffer } = await downloadAudioToBuffer(fileUrl);
+    return buffer;
+  } catch {
+    return null;
+  }
+}
+
+async function uploadSyncedLyricsIfAvailable(
+  storage: StorageProvider,
+  sourceAudioUrl: string,
+  finalAudioStorageKey: string
+): Promise<void> {
+  const lyricCandidates = [
+    replaceExtension(sourceAudioUrl, '.lrc'),
+    replaceExtension(sourceAudioUrl, '.vtt'),
+  ];
+
+  for (const lyricUrl of lyricCandidates) {
+    const lyricBuffer = await readGeneratedCompanionFile(lyricUrl);
+    if (!lyricBuffer || lyricBuffer.length === 0) continue;
+
+    const lrcStorageKey = replaceExtension(finalAudioStorageKey, '.lrc');
+    try {
+      await storage.upload(lrcStorageKey, lyricBuffer, 'text/plain; charset=utf-8');
+      console.log(`Stored synced lyrics for ${sourceAudioUrl} at ${storage.getPublicUrl(lrcStorageKey)}`);
+    } catch (err) {
+      console.warn(`Failed to store synced lyrics for ${sourceAudioUrl}:`, err);
+    }
+    return;
+  }
 }
 
 const audioUpload = multer({
@@ -148,10 +196,16 @@ interface GenerateBody {
   lmBatchChunkSize?: number;
   trackName?: string;
   completeTrackClasses?: string[];
+  dcwEnabled?: boolean;
+  dcwMode?: string;
+  dcwScaler?: number;
+  dcwHighScaler?: number;
+  dcwWavelet?: string;
   isFormatCaption?: boolean;
 
   // Model selection
   ditModel?: string;
+  vaeModel?: string;
 }
 
 router.post('/upload-audio', authMiddleware, (req: AuthenticatedRequest, res: Response, next: Function) => {
@@ -265,6 +319,12 @@ router.post('/', authMiddleware, async (req: AuthenticatedRequest, res: Response
       completeTrackClasses,
       isFormatCaption,
       ditModel,
+      dcwEnabled,
+      dcwMode,
+      dcwScaler,
+      dcwHighScaler,
+      dcwWavelet,
+      vaeModel,
     } = req.body as GenerateBody;
 
     if (!customMode && !songDescription) {
@@ -333,6 +393,12 @@ router.post('/', authMiddleware, async (req: AuthenticatedRequest, res: Response
       completeTrackClasses,
       isFormatCaption,
       ditModel,
+      dcwEnabled,
+      dcwMode,
+      dcwScaler,
+      dcwHighScaler,
+      dcwWavelet,
+      vaeModel,
     };
 
     // Create job record in database
@@ -424,12 +490,17 @@ router.get('/status/:jobId', authMiddleware, async (req: AuthenticatedRequest, r
               const songTitle = autoTitle(params) + variationSuffix;
 
               const songId = generateUUID();
+              const scorePayload = Array.isArray(aceStatus.result.scores) ? aceStatus.result.scores[i] : undefined;
+              const songGenerationParams = scorePayload
+                ? { ...params, score: scorePayload, scores: scorePayload }
+                : params;
 
               try {
                 const { buffer } = await downloadAudioToBuffer(audioUrl);
                 const ext = audioUrl.includes('.flac') ? '.flac' : '.mp3';
                 const storageKey = `${req.user!.id}/${songId}${ext}`;
                 await storage.upload(storageKey, buffer, `audio/${ext.slice(1)}`);
+                await uploadSyncedLyricsIfAvailable(storage, audioUrl, storageKey);
                 const storedPath = storage.getPublicUrl(storageKey);
 
                 await pool.query(
@@ -450,7 +521,7 @@ router.get('/status/:jobId', authMiddleware, async (req: AuthenticatedRequest, r
                     aceStatus.result.keyScale || params.keyScale,
                     aceStatus.result.timeSignature || params.timeSignature,
                     JSON.stringify([]),
-                    JSON.stringify(params),
+                    JSON.stringify(songGenerationParams),
                   ]
                 );
 
@@ -476,7 +547,7 @@ router.get('/status/:jobId', authMiddleware, async (req: AuthenticatedRequest, r
                     aceStatus.result.keyScale || params.keyScale,
                     aceStatus.result.timeSignature || params.timeSignature,
                     JSON.stringify([]),
-                    JSON.stringify(params),
+                    JSON.stringify(songGenerationParams),
                   ]
                 );
                 localPaths.push(audioUrl);
@@ -598,7 +669,8 @@ router.get('/endpoints', authMiddleware, async (_req: AuthenticatedRequest, res:
 
 router.get('/models', async (_req, res: Response) => {
   try {
-    const ACESTEP_DIR = process.env.ACESTEP_PATH || path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../ACE-Step-1.5');
+    // const ACESTEP_DIR = process.env.ACESTEP_PATH || path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../ACE-Step-1.5');
+    const ACESTEP_DIR = resolveAceStepPath();
     const checkpointsDir = path.join(ACESTEP_DIR, 'checkpoints');
 
     // All known DiT models from Gradio's model_downloader.py registry:
@@ -668,7 +740,32 @@ router.get('/models', async (_req, res: Response) => {
       return a.name.localeCompare(b.name);
     });
 
-    res.json({ models });
+     // Scan for available VAE checkpoints
+    const vaeModels = [
+      { name: 'official', is_preloaded: true },
+      { name: 'scragvae', is_preloaded: existsSync(path.join(checkpointsDir, 'scragvae')) },
+    ];
+    try {
+      const { readdirSync } = await import('fs');
+      for (const entry of readdirSync(checkpointsDir)) {
+        if (!['vae', 'scragvae', 'Qwen3-Embedding-0.6B', 'acestep-5Hz-lm-0.6B', 'acestep-5Hz-lm-1.7B', 'acestep-5Hz-lm-4B'].includes(entry) && 
+            !entry.startsWith('acestep-v15-') &&
+            statSync(path.join(checkpointsDir, entry)).isDirectory()) {
+          const entryPath = path.join(checkpointsDir, entry);
+          if (existsSync(path.join(entryPath, 'diffusion_pytorch_model.safetensors')) || 
+              existsSync(path.join(entryPath, 'model.safetensors')) || 
+              existsSync(path.join(entryPath, 'pytorch_model.bin'))) {
+            if (!vaeModels.some(v => v.name === entry)) {
+              vaeModels.push({
+                name: entry,
+                is_preloaded: true
+              });
+            }
+          }
+        }
+      }
+    } catch { /* checkpoints dir may not exist */ }
+    res.json({ models, vaeModels });
   } catch (error) {
     console.error('Models error:', error);
     res.status(500).json({ error: (error as Error).message });
@@ -705,7 +802,8 @@ router.get('/health', async (_req, res: Response) => {
 router.get('/limits', async (_req, res: Response) => {
   try {
     const { spawn } = await import('child_process');
-    const ACESTEP_DIR = process.env.ACESTEP_PATH || path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../ACE-Step-1.5');
+    // const ACESTEP_DIR = process.env.ACESTEP_PATH || path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../ACE-Step-1.5');
+    const ACESTEP_DIR = resolveAceStepPath();
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
     const SCRIPTS_DIR = path.join(__dirname, '../../scripts');
@@ -836,7 +934,8 @@ router.post('/format', authMiddleware, async (req: AuthenticatedRequest, res: Re
 
     // Fallback: Python spawn (only reached when REST API is unreachable)
     const { spawn } = await import('child_process');
-    const ACESTEP_DIR = process.env.ACESTEP_PATH || path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../ACE-Step-1.5');
+    // const ACESTEP_DIR = process.env.ACESTEP_PATH || path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../ACE-Step-1.5');
+    const ACESTEP_DIR = resolveAceStepPath();
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
     const SCRIPTS_DIR = path.join(__dirname, '../../scripts');

--- a/server/src/services/acestep.ts
+++ b/server/src/services/acestep.ts
@@ -134,77 +134,110 @@ async function buildGradioArgs(params: GenerationParams): Promise<unknown[]> {
   const caption = params.style || 'pop music';
   const prompt = params.customMode ? caption : (params.songDescription || caption);
   const lyrics = params.instrumental ? '' : (params.lyrics || '');
+  
+  // Enable thinking
   const isThinking = params.thinking ?? false;
   const isEnhance = params.enhance ?? false;
 
-  // Prepare audio files (async — reads from disk)
+  // Data pre-cleaning and type safety validation
+  let cleanTopK = 0;
+  if (params.lmTopK && (params.lmTopK as any) !== 'Auto') {
+      cleanTopK = Number(params.lmTopK);
+  }
+
+  const cleanBpm = params.bpm && params.bpm > 0 ? Number(params.bpm) : 0;
+  const cleanSteps = params.inferenceSteps ? Number(params.inferenceSteps) : 8;
+  const cleanGuidance = params.guidanceScale ? Number(params.guidanceScale) : 7.0;
+  const cleanDuration = params.duration && params.duration > 0 ? Number(params.duration) : -1;
+  const cleanBatchSize = Math.min(Math.max(params.batchSize ?? 1, 1), 16);
+  const cleanTemperature = params.lmTemperature ? Number(params.lmTemperature) : 0.85;
+  const cleanLmCfg = params.lmCfgScale ? Number(params.lmCfgScale) : 2.0;
+  const cleanTopP = params.lmTopP ? Number(params.lmTopP) : 0.9;
+  const cleanScoreScale = params.scoreScale ? Number(params.scoreScale) : 0.5;
+  const cleanChunkSize = params.lmBatchChunkSize ? Number(params.lmBatchChunkSize) : 8;
+
+  // Prepare audio files
   const referenceAudio = await prepareAudioFile(params.referenceAudioUrl);
   const sourceAudio = await prepareAudioFile(params.sourceAudioUrl);
 
-  // Guard: cover/repaint modes require source audio to be loadable
   const needsSource = params.taskType === 'cover' || params.taskType === 'audio2audio' || params.taskType === 'repaint';
   if (needsSource && params.sourceAudioUrl && sourceAudio === null) {
-    throw new Error(`Source audio file could not be loaded from: ${params.sourceAudioUrl}. Make sure the file was uploaded successfully.`);
+    throw new Error(`Source audio file could not be loaded...`);
   }
 
-  // CoT features are gated by enhance OR thinking (either enables LLM enrichment)
   const useCot = isEnhance || isThinking;
 
-  return [
-    prompt,                                                       //  0: Music Caption
-    lyrics,                                                       //  1: Lyrics
-    params.bpm && params.bpm > 0 ? params.bpm : 0,               //  2: BPM (0 = auto)
-    params.keyScale || '',                                        //  3: KeyScale
-    params.timeSignature || '',                                   //  4: Time Signature
-    params.vocalLanguage || 'en',                                 //  5: Vocal Language
-    params.inferenceSteps ?? 8,                                   //  6: DiT Inference Steps
-    params.guidanceScale ?? 7.0,                                  //  7: DiT Guidance Scale
-    params.randomSeed !== false,                                  //  8: Random Seed
-    String(params.seed ?? -1),                                    //  9: Seed
-    referenceAudio,                                               // 10: Reference Audio (filepath | null)
-    params.duration && params.duration > 0 ? params.duration : -1, // 11: Audio Duration (-1 = auto)
-    Math.min(Math.max(params.batchSize ?? 1, 1), 16),            // 12: Batch Size (clamped 1-16)
-    sourceAudio,                                                  // 13: Source Audio (filepath | null)
-    params.audioCodes || '',                                      // 14: LM Codes Hints
-    params.repaintingStart ?? 0.0,                                // 15: Repainting Start
-    params.repaintingEnd ?? -1,                                   // 16: Repainting End
-    params.instruction || 'Fill the audio semantic mask with the style described in the text prompt.', // 17: Instruction
-    params.audioCoverStrength ?? 1.0,                             // 18: Audio Cover Strength
-    0.0,                                                          // 19: Cover Noise Strength (ACE-Step v1.5 new param, default 0.0)
-    (params.taskType === 'audio2audio' ? 'cover' : params.taskType) || 'text2music', // 20: Task Type
-    params.useAdg ?? false,                                       // 21: Use ADG
-    params.cfgIntervalStart ?? 0.0,                               // 22: CFG Interval Start
-    params.cfgIntervalEnd ?? 1.0,                                 // 23: CFG Interval End
-    params.shift ?? 3.0,                                          // 24: Shift
-    params.inferMethod || 'ode',                                  // 25: Inference Method
-    params.customTimesteps || '',                                 // 26: Custom Timesteps
-    params.audioFormat || 'mp3',                                  // 27: Audio Format
-    params.lmTemperature ?? 0.85,                                 // 28: LM Temperature
-    isThinking,                                                   // 29: Think
-    params.lmCfgScale ?? 2.0,                                    // 30: LM CFG Scale
-    params.lmTopK ?? 0,                                           // 31: LM Top-K
-    params.lmTopP ?? 0.9,                                         // 32: LM Top-P
-    params.lmNegativePrompt || 'NO USER INPUT',                   // 33: LM Negative Prompt
-    useCot ? (params.useCotMetas ?? true) : false,                // 34: CoT Metas
-    useCot ? (params.useCotCaption ?? true) : false,              // 35: CaptionRewrite
-    useCot ? (params.useCotLanguage ?? true) : false,             // 36: CoT Language
-    params.isFormatCaption ?? false,                              // 37: Is Format Caption State
-    params.constrainedDecodingDebug ?? false,                     // 38: Constrained Decoding Debug
-    params.allowLmBatch ?? true,                                  // 39: ParallelThinking
-    params.getScores ?? false,                                    // 40: Auto Score
-    params.getLrc ?? false,                                       // 41: Auto LRC (timestamped lyrics)
-    params.scoreScale ?? 0.5,                                     // 42: Quality Score Sensitivity (0.01-1.0)
-    params.lmBatchChunkSize ?? 8,                                 // 43: LM Batch Chunk Size
-    params.trackName || null,                                     // 44: Track Name
-    params.completeTrackClasses || [],                            // 45: Track Names
-    true,                                                         // 46: Enable Normalization (ACE-Step v1.5, default true)
-    -1.0,                                                         // 47: Normalization DB (ACE-Step v1.5, default -1.0)
-    0.0,                                                          // 48: Latent Shift (ACE-Step v1.5, default 0.0)
-    1.0,                                                          // 49: Latent Rescale (ACE-Step v1.5, default 1.0)
-    params.autogen ?? false,                                      // 50: AutoGen
-    // Note: current_batch_index, total_batches, batch_queue, generation_params_state
-    // are hidden Gradio state variables and must NOT be passed via client.predict()
+  // Complete raw positional arguments array
+  const rawArgs = [
+    prompt,                                                       // Music Caption
+    lyrics,                                                       // Lyrics
+    cleanBpm,                                                     // BPM
+    params.keyScale || '',                                        // KeyScale
+    params.timeSignature || '',                                   // Time Signature
+    params.vocalLanguage || 'en',                                 // Vocal Language
+    cleanSteps,                                                   // DiT Inference Steps
+    cleanGuidance,                                                // DiT Guidance Scale
+    params.randomSeed !== false,                                  // Random Seed
+    Number(params.seed ?? -1),                                    // Seed
+    referenceAudio,                                               // Reference Audio
+    cleanDuration,                                                // Audio Duration
+    cleanBatchSize,                                               // Batch Size
+    sourceAudio,                                                  // Source Audio
+    params.audioCodes || '',                                      // LM Codes Hints
+    params.repaintingStart ?? 0.0,                                // Repainting Start
+    params.repaintingEnd ?? -1,                                   // Repainting End
+    params.instruction || 'Fill the audio semantic mask...',       // Instruction
+    params.audioCoverStrength ?? 1.0,                             // Audio Cover Strength
+    0.0,                                                          // Cover Noise Strength
+    (params.taskType === 'audio2audio' ? 'cover' : params.taskType) || 'text2music', // Task Type
+    params.useAdg ?? false,                                       // Use ADG
+    params.cfgIntervalStart ?? 0.0,                               // CFG Interval Start
+    params.cfgIntervalEnd ?? 1.0,                                 // CFG Interval End
+    params.shift ?? 3.0,                                          // Shift
+    params.inferMethod || 'ode',                                  // Inference Method
+    params.customTimesteps || '',                                 // Custom Timesteps
+    params.audioFormat || 'mp3',                                  // Audio Format
+    cleanTemperature,                                             // LM Temperature
+    isThinking,                                                   // Think
+    cleanLmCfg,                                                   // LM CFG Scale
+    cleanTopK,                                                    // LM Top-K
+    cleanTopP,                                                    // LM Top-P
+    params.lmNegativePrompt || 'NO USER INPUT',                   // LM Negative Prompt
+    useCot ? (params.useCotMetas ?? true) : false,                // CoT Metas
+    useCot ? (params.useCotCaption ?? true) : false,              // CaptionRewrite
+    useCot ? (params.useCotLanguage ?? true) : false,             // CoT Language
+    params.isFormatCaption ?? false,                              // Is Format Caption State
+    params.constrainedDecodingDebug ?? false,                     // Constrained Decoding Debug
+    params.allowLmBatch ?? true,                                  // ParallelThinking
+    params.getScores ?? false,                                    // Auto Score
+    params.getLrc ?? false,                                       // Auto LRC
+    cleanScoreScale,                                              // Quality Score Sensitivity
+    cleanChunkSize,                                               // LM Batch Chunk Size
+    params.trackName || null,                                     // Track Name
+    params.completeTrackClasses || [],                            // Track Names
+    true,                                                         // Enable Normalization
+    -1.0,                                                         // Normalization DB
+    0.0,                                                          // Latent Shift
+    1.0,                                                          // Latent Rescale
+    params.autogen ?? false,                                      // AutoGen
   ];
+
+  // Type coercion and normalization map to ensure exact types for Gradio
+  return rawArgs.map((val, idx) => {
+    const isStringOrObjSlot = [0, 1, 3, 4, 5, 10, 13, 14, 17, 20, 25, 26, 27, 33, 44, 45].includes(idx);
+    
+    if (!isStringOrObjSlot) {
+      if (typeof val === 'string' && (val.toLowerCase() === 'true' || val.toLowerCase() === 'false')) {
+        return val.toLowerCase() === 'true';
+      }
+      
+      if (typeof val === 'string' || val === undefined || val === null) {
+        const parsed = Number(val || 0);
+        return isNaN(parsed) ? 0 : parsed;
+      }
+    }
+    return val;
+  });
 }
 
 /**
@@ -541,11 +574,6 @@ async function processGenerationViaGradio(
   }
 
   // Extract audio files from the result
-  // Outputs 0-7: individual audio samples (filepath objects)
-  // Output 8: "All Generated Files" as list[filepath]
-  // Output 9: "Generation Details" (string)
-  // Output 10: "Generation Status" (string)
-  // Output 11: "Seed" (string)
   const allFiles = data[8]; // list of file objects
   const genDetails = data[9] as string | undefined;
   const genStatus = data[10] as string | undefined;
@@ -625,7 +653,6 @@ function parseGenerationDetails(details: string | undefined): {
 } {
   if (!details) return {};
   try {
-    // Generation details may contain key-value pairs
     const bpmMatch = details.match(/BPM:\s*(\d+)/i);
     const durationMatch = details.match(/Duration:\s*([\d.]+)/i);
     const keyMatch = details.match(/Key:\s*([A-G][#b]?\s*(?:major|minor))/i);
@@ -684,6 +711,7 @@ async function processGenerationViaPython(
     if (params.timeSignature) args.push('--time-signature', params.timeSignature);
     if (params.vocalLanguage) args.push('--vocal-language', params.vocalLanguage);
     if (params.seed !== undefined && params.seed >= 0 && !params.randomSeed) args.push('--seed', String(params.seed));
+    
     if (params.shift !== undefined) args.push('--shift', String(params.shift));
     const resolvedTaskType = params.taskType === 'audio2audio' ? 'cover' : params.taskType;
     if (resolvedTaskType && resolvedTaskType !== 'text2music') args.push('--task-type', resolvedTaskType);
@@ -706,13 +734,28 @@ async function processGenerationViaPython(
     if (params.thinking) args.push('--thinking');
     if (params.lmTemperature !== undefined) args.push('--lm-temperature', String(params.lmTemperature));
     if (params.lmCfgScale !== undefined) args.push('--lm-cfg-scale', String(params.lmCfgScale));
-    if (params.lmTopK !== undefined && params.lmTopK > 0) args.push('--lm-top-k', String(params.lmTopK));
+    
+    if (params.lmTopK as any === 'Auto' || !params.lmTopK) {
+        params.lmTopK = 0;
+    } else {
+        params.lmTopK = Number(params.lmTopK);
+    }
+    if (params.lmTopK && params.lmTopK > 0) args.push('--lm-top-k', String(params.lmTopK));
     if (params.lmTopP !== undefined) args.push('--lm-top-p', String(params.lmTopP));
     if (params.lmNegativePrompt) args.push('--lm-negative-prompt', params.lmNegativePrompt);
-    // Note: --lm-backend and --lm-model are not supported by simple_generate.py
-    if (params.useCotMetas === false) args.push('--no-cot-metas');
-    if (params.useCotCaption === false) args.push('--no-cot-caption');
-    if (params.useCotLanguage === false) args.push('--no-cot-language');
+    if (params.lmModel) args.push('--lm-model', params.lmModel);
+    if (params.lmBackend) args.push('--lm-backend', params.lmBackend);
+
+    const useCot = (params.enhance ?? false) || (params.thinking ?? false);
+    if (!useCot) {
+      args.push('--no-cot-metas');
+      args.push('--no-cot-caption');
+      args.push('--no-cot-language');
+    } else {
+      if (params.useCotMetas === false) args.push('--no-cot-metas');
+      if (params.useCotCaption === false) args.push('--no-cot-caption');
+      if (params.useCotLanguage === false) args.push('--no-cot-language');
+    }
     if (params.useAdg) args.push('--use-adg');
     if (params.cfgIntervalStart !== undefined && params.cfgIntervalStart > 0) args.push('--cfg-interval-start', String(params.cfgIntervalStart));
     if (params.cfgIntervalEnd !== undefined && params.cfgIntervalEnd < 1.0) args.push('--cfg-interval-end', String(params.cfgIntervalEnd));
@@ -793,10 +836,13 @@ function runPythonGeneration(scriptArgs: string[], timeoutMs = 600000): Promise<
       env: {
         ...process.env,
         ACESTEP_PATH: ACESTEP_DIR,
+        PYTHONIOENCODING: 'utf-8',
+        PYTHONUTF8: '1',
+        LANG: 'C.UTF-8',
+        LC_ALL: 'C.UTF-8'
       },
     });
 
-    // Kill process after timeout (default 10 minutes)
     const timer = setTimeout(() => {
       proc.kill('SIGTERM');
       setTimeout(() => { if (!proc.killed) proc.kill('SIGKILL'); }, 5000);
@@ -851,7 +897,7 @@ function runPythonGeneration(scriptArgs: string[], timeoutMs = 600000): Promise<
 }
 
 // ---------------------------------------------------------------------------
-// Job status (simplified — no more REST polling for progress)
+// Job status 
 // ---------------------------------------------------------------------------
 
 export async function getJobStatus(jobId: string): Promise<JobStatus> {
@@ -888,7 +934,6 @@ export async function getJobStatus(jobId: string): Promise<JobStatus> {
     };
   }
 
-  // Running — Gradio handles its own queue, we just report estimated time
   return {
     status: job.status,
     etaSeconds: Math.max(0, 180 - elapsed),
@@ -897,14 +942,13 @@ export async function getJobStatus(jobId: string): Promise<JobStatus> {
   };
 }
 
-// Get raw response for debugging
 export function getJobRawResponse(jobId: string): unknown | null {
   const job = activeJobs.get(jobId);
   return job?.rawResponse || null;
 }
 
 // ---------------------------------------------------------------------------
-// Audio helpers (unchanged)
+// Audio helpers
 // ---------------------------------------------------------------------------
 
 export async function getAudioStream(audioPath: string): Promise<Response> {
@@ -927,7 +971,6 @@ export async function getAudioStream(audioPath: string): Promise<Response> {
     }
   }
 
-  // Absolute path — try reading directly from disk (Gradio output files)
   if (audioPath.startsWith('/')) {
     try {
       const buffer = await readFile(audioPath);
@@ -937,7 +980,7 @@ export async function getAudioStream(audioPath: string): Promise<Response> {
         headers: { 'Content-Type': `audio/${ext}` }
       });
     } catch {
-      // Fall through to Gradio API
+      // Fall through
     }
   }
 

--- a/server/src/services/acestep.ts
+++ b/server/src/services/acestep.ts
@@ -29,10 +29,26 @@ const AUDIO_DIR = path.join(__dirname, '../../public/audio');
 const ACESTEP_API = config.acestep.apiUrl;
 
 // Resolve ACE-Step path (from env or default relative path)
-function resolveAceStepPath(): string {
+export function resolveAceStepPath(): string {
   const envPath = process.env.ACESTEP_PATH;
   if (envPath) {
     return path.isAbsolute(envPath) ? envPath : path.resolve(process.cwd(), envPath);
+  }
+  
+ // Sibling directories search order (checks all common names including case variations)
+  const candidateSiblings = [
+    'ACEStep1.5',
+    'ACEStep-1.5',
+    'ACE1.5',
+    'ACE-Step-1.5',
+    'ace-step-1.5',
+    'ace1.5'
+  ];
+  for (const sibling of candidateSiblings) {
+    const siblingPath = path.resolve(__dirname, `../../../${sibling}`);
+    if (existsSync(siblingPath)) {
+      return siblingPath;
+    }
   }
   // Default: sibling directory (server/src/services -> ../../../ACE-Step-1.5 = app/ACE-Step-1.5)
   return path.resolve(__dirname, '../../../ACE-Step-1.5');
@@ -72,7 +88,7 @@ export function resolvePythonPath(baseDir: string): string {
   return path.join(baseDir, 'env', 'bin', 'python');
 }
 
-const ACESTEP_DIR = resolveAceStepPath();
+let ACESTEP_DIR = resolveAceStepPath();
 const SCRIPTS_DIR = path.join(__dirname, '../../scripts');
 const PYTHON_SCRIPT = path.join(SCRIPTS_DIR, 'simple_generate.py');
 
@@ -167,64 +183,93 @@ async function buildGradioArgs(params: GenerationParams): Promise<unknown[]> {
 
   const useCot = isEnhance || isThinking;
 
-  // Complete raw positional arguments array
+  // Complete raw positional arguments array aligned exactly with the 78 inputs of generation_wrapper in generation_run_wiring.py
   const rawArgs = [
-    prompt,                                                       // Music Caption
-    lyrics,                                                       // Lyrics
-    cleanBpm,                                                     // BPM
-    params.keyScale || '',                                        // KeyScale
-    params.timeSignature || '',                                   // Time Signature
-    params.vocalLanguage || 'en',                                 // Vocal Language
-    cleanSteps,                                                   // DiT Inference Steps
-    cleanGuidance,                                                // DiT Guidance Scale
-    params.randomSeed !== false,                                  // Random Seed
-    Number(params.seed ?? -1),                                    // Seed
-    referenceAudio,                                               // Reference Audio
-    cleanDuration,                                                // Audio Duration
-    cleanBatchSize,                                               // Batch Size
-    sourceAudio,                                                  // Source Audio
-    params.audioCodes || '',                                      // LM Codes Hints
-    params.repaintingStart ?? 0.0,                                // Repainting Start
-    params.repaintingEnd ?? -1,                                   // Repainting End
-    params.instruction || 'Fill the audio semantic mask...',       // Instruction
-    params.audioCoverStrength ?? 1.0,                             // Audio Cover Strength
-    0.0,                                                          // Cover Noise Strength
-    (params.taskType === 'audio2audio' ? 'cover' : params.taskType) || 'text2music', // Task Type
-    params.useAdg ?? false,                                       // Use ADG
-    params.cfgIntervalStart ?? 0.0,                               // CFG Interval Start
-    params.cfgIntervalEnd ?? 1.0,                                 // CFG Interval End
-    params.shift ?? 3.0,                                          // Shift
-    params.inferMethod || 'ode',                                  // Inference Method
-    params.customTimesteps || '',                                 // Custom Timesteps
-    params.audioFormat || 'mp3',                                  // Audio Format
-    cleanTemperature,                                             // LM Temperature
-    isThinking,                                                   // Think
-    cleanLmCfg,                                                   // LM CFG Scale
-    cleanTopK,                                                    // LM Top-K
-    cleanTopP,                                                    // LM Top-P
-    params.lmNegativePrompt || 'NO USER INPUT',                   // LM Negative Prompt
-    useCot ? (params.useCotMetas ?? true) : false,                // CoT Metas
-    useCot ? (params.useCotCaption ?? true) : false,              // CaptionRewrite
-    useCot ? (params.useCotLanguage ?? true) : false,             // CoT Language
-    params.isFormatCaption ?? false,                              // Is Format Caption State
-    params.constrainedDecodingDebug ?? false,                     // Constrained Decoding Debug
-    params.allowLmBatch ?? true,                                  // ParallelThinking
-    params.getScores ?? false,                                    // Auto Score
-    params.getLrc ?? false,                                       // Auto LRC
-    cleanScoreScale,                                              // Quality Score Sensitivity
-    cleanChunkSize,                                               // LM Batch Chunk Size
-    params.trackName || null,                                     // Track Name
-    params.completeTrackClasses || [],                            // Track Names
-    true,                                                         // Enable Normalization
-    -1.0,                                                         // Normalization DB
-    0.0,                                                          // Latent Shift
-    1.0,                                                          // Latent Rescale
-    params.autogen ?? false,                                      // AutoGen
+    prompt,                                                       // 0: Music Caption
+    lyrics,                                                       // 1: Lyrics
+    cleanBpm,                                                     // 2: BPM
+    params.keyScale || '',                                        // 3: KeyScale
+    params.timeSignature || '',                                   // 4: Time Signature
+    params.vocalLanguage || 'en',                                 // 5: Vocal Language
+    cleanSteps,                                                   // 6: DiT Inference Steps
+    cleanGuidance,                                                // 7: DiT Guidance Scale
+    params.randomSeed !== false,                                  // 8: Random Seed
+    Number(params.seed ?? -1),                                    // 9: Seed
+    referenceAudio,                                               // 10: Reference Audio
+    cleanDuration,                                                // 11: Audio Duration
+    cleanBatchSize,                                               // 12: Batch Size
+    sourceAudio,                                                  // 13: Source Audio
+    params.audioCodes || '',                                      // 14: LM Codes Hints
+    params.repaintingStart ?? 0.0,                                // 15: Repainting Start
+    params.repaintingEnd ?? -1,                                   // 16: Repainting End
+    params.instruction || 'Fill the audio semantic mask...',       // 17: Instruction
+    params.audioCoverStrength ?? 1.0,                             // 18: Audio Cover Strength
+    0.0,                                                          // 19: Cover Noise Strength
+    (params.taskType === 'audio2audio' ? 'cover' : params.taskType) || 'text2music', // 20: Task Type
+    false,                                                        // 21: no_fsq
+    params.useAdg ?? false,                                       // 22: use_adg
+    params.cfgIntervalStart ?? 0.0,                               // 23: cfg_interval_start
+    params.cfgIntervalEnd ?? 1.0,                                 // 24: cfg_interval_end
+    params.shift ?? 3.0,                                          // 25: shift
+    params.inferMethod || 'ode',                                  // 26: infer_method
+    'euler',                                                      // 27: sampler_mode
+    0.0,                                                          // 28: velocity_norm_threshold
+    0.0,                                                          // 29: velocity_ema_factor
+    params.dcwEnabled ?? true,                                    // 30: dcw_enabled
+    params.dcwMode || 'double',                                   // 31: dcw_mode
+    params.dcwScaler !== undefined ? params.dcwScaler : (isThinking ? 0.02 : 0.05), // 32: dcw_scaler
+    params.dcwHighScaler !== undefined ? params.dcwHighScaler : (isThinking ? 0.06 : 0.02), // 33: dcw_high_scaler
+    params.dcwWavelet || 'haar',                                  // 34: dcw_wavelet
+    params.customTimesteps || '',                                 // 35: custom_timesteps
+    params.audioFormat || 'mp3',                                  // 36: audio_format
+    '128k',                                                       // 37: mp3_bitrate
+    48000,                                                        // 38: mp3_sample_rate
+    cleanTemperature,                                             // 39: lm_temperature
+    isThinking,                                                   // 40: think_checkbox
+    cleanLmCfg,                                                   // 41: lm_cfg_scale
+    cleanTopK,                                                    // 42: lm_top_k
+    cleanTopP,                                                    // 43: lm_top_p
+    params.lmNegativePrompt || 'NO USER INPUT',                   // 44: lm_negative_prompt
+    useCot ? (params.useCotMetas ?? true) : false,                // 45: use_cot_metas
+    useCot ? (params.useCotCaption ?? true) : false,              // 46: use_cot_caption
+    useCot ? (params.useCotLanguage ?? true) : false,             // 47: use_cot_language
+    params.isFormatCaption ?? false,                              // 48: is_format_caption_state
+    params.constrainedDecodingDebug ?? false,                     // 49: constrained_decoding_debug
+    params.allowLmBatch ?? true,                                  // 50: allow_lm_batch
+    params.getScores ?? false,                                    // 51: auto_score
+    params.getLrc ?? false,                                       // 52: auto_lrc
+    cleanScoreScale,                                              // 53: score_scale
+    cleanChunkSize,                                               // 54: lm_batch_chunk_size
+    params.trackName || null,                                     // 55: track_name
+    params.completeTrackClasses || [],                            // 56: complete_track_classes
+    true,                                                         // 57: enable_normalization
+    -1.0,                                                         // 58: normalization_db
+    0.0,                                                          // 59: fade_in_duration
+    0.0,                                                          // 60: fade_out_duration
+    0.0,                                                          // 61: latent_shift
+    1.0,                                                          // 62: latent_rescale
+    'balanced',                                                   // 63: repaint_mode
+    0.5,                                                          // 64: repaint_strength
+    0.0,                                                          // 65: retake_variance
+    '',                                                           // 66: retake_seed
+    false,                                                        // 67: flow_edit_morph
+    '',                                                           // 68: flow_edit_source_caption
+    '',                                                           // 69: flow_edit_source_lyrics
+    0.0,                                                          // 70: flow_edit_n_min
+    1.0,                                                          // 71: flow_edit_n_max
+    1,                                                            // 72: flow_edit_n_avg
+    params.autogen ?? false,                                      // 73: autogen_checkbox
+    0,                                                            // 74: current_batch_index
+    1,                                                            // 75: total_batches
+    null,                                                         // 76: batch_queue
+    null,                                                         // 77: generation_params_state
   ];
 
   // Type coercion and normalization map to ensure exact types for Gradio
   return rawArgs.map((val, idx) => {
-    const isStringOrObjSlot = [0, 1, 3, 4, 5, 10, 13, 14, 17, 20, 25, 26, 27, 33, 44, 45].includes(idx);
+    const isStringOrObjSlot = [
+      0, 1, 3, 4, 5, 10, 13, 14, 17, 20, 26, 27, 31, 34, 35, 36, 37, 44, 55, 56, 63, 66, 68, 69, 76, 77
+    ].includes(idx);
     
     if (!isStringOrObjSlot) {
       if (typeof val === 'string' && (val.toLowerCase() === 'true' || val.toLowerCase() === 'false')) {
@@ -352,9 +397,14 @@ export interface GenerationParams {
   trackName?: string;
   completeTrackClasses?: string[];
   isFormatCaption?: boolean;
-
+  dcwEnabled?: boolean;
+  dcwMode?: string;
+  dcwScaler?: number;
+  dcwHighScaler?: number;
+  dcwWavelet?: string;
   // Model selection
   ditModel?: string;
+  vaeModel?: string;
 }
 
 interface GenerationResult {
@@ -363,6 +413,7 @@ interface GenerationResult {
   bpm?: number;
   keyScale?: string;
   timeSignature?: string;
+  scores?: string[];
   status: string;
 }
 
@@ -433,7 +484,10 @@ async function switchModelIfNeeded(ditModel: string): Promise<void> {
 
   if (!res.ok) {
     const err = await res.text().catch(() => '');
-    throw new Error(`Model switch to '${ditModel}' failed: ${res.status} ${err}`);
+    if (res.status === 404) {
+      console.warn(`[Model] Model switch API (/v1/init) not supported by older ACE-Step backend (404). Proceeding to generation with default/preloaded model.`);
+      return;
+    }
   }
   console.log(`[Model] Switched to '${ditModel}'`);
 }
@@ -485,6 +539,9 @@ async function processQueue(): Promise<void> {
 
 // Submit generation job to queue
 export async function generateMusicViaAPI(params: GenerationParams): Promise<{ jobId: string }> {
+  // Re-evaluate ACESTEP_DIR in case process.env.ACESTEP_PATH was updated at runtime
+  ACESTEP_DIR = resolveAceStepPath();
+
   const jobId = `job_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
 
   const job: ActiveJob = {
@@ -540,6 +597,33 @@ async function processGeneration(
   await processGenerationViaPython(jobId, params, job);
 }
 
+/**
+ * Dynamically align Gradio raw arguments array to match the exact input length
+ * expected by the remote Gradio /generation_wrapper API endpoint.
+ * This guarantees complete forward and backward compatibility across versions.
+ */
+function alignGradioArgs(args: unknown[], client: any): unknown[] {
+  try {
+    const dependency = client.config?.dependencies?.find((d: any) => d.api_name === 'generation_wrapper');
+    if (dependency && Array.isArray(dependency.inputs)) {
+      const expectedLength = dependency.inputs.length;
+      console.log(`[ACE-Step] [Gradio] Dynamic alignment: remote expects ${expectedLength} inputs, local payload has ${args.length} inputs`);
+      if (args.length > expectedLength) {
+        return args.slice(0, expectedLength);
+      } else if (args.length < expectedLength) {
+        const padded = [...args];
+        while (padded.length < expectedLength) {
+          padded.push(null);
+        }
+        return padded;
+      }
+    }
+  } catch (err) {
+    console.warn('[ACE-Step] [Gradio] Failed to dynamically align Gradio arguments:', err);
+  }
+  return args;
+}
+
 async function processGenerationViaGradio(
   jobId: string,
   params: GenerationParams,
@@ -553,6 +637,7 @@ async function processGenerationViaGradio(
 
   const client = await getGradioClient();
   const args = await buildGradioArgs(params);
+  const alignedArgs = alignGradioArgs(args, client);
 
   const caption = params.style || 'pop music';
   const prompt = params.customMode ? caption : (params.songDescription || caption);
@@ -566,7 +651,8 @@ async function processGenerationViaGradio(
   job.stage = 'Generating music via Gradio...';
 
   // predict() blocks until generation is complete
-  const result = await client.predict('/generation_wrapper', args);
+  // const result = await client.predict('/generation_wrapper', args);
+  const result = await client.predict('/generation_wrapper', alignedArgs);
   const data = result.data as unknown[];
 
   if (!Array.isArray(data) || data.length === 0) {
@@ -577,6 +663,7 @@ async function processGenerationViaGradio(
   const allFiles = data[8]; // list of file objects
   const genDetails = data[9] as string | undefined;
   const genStatus = data[10] as string | undefined;
+  const scoreOutputs = extractGradioScoreOutputs(data);
 
   // Collect audio file objects — prefer the "All Generated Files" list
   let audioFileObjects: Array<{ url?: string; path?: string; orig_name?: string }> = [];
@@ -611,8 +698,38 @@ async function processGenerationViaGradio(
     const ext = origName.includes('.flac') ? '.flac' : `.${audioFormat}`;
     const filename = `${jobId}_${audioUrls.length}${ext}`;
     const destPath = path.join(AUDIO_DIR, filename);
+    const sampleIndex = audioUrls.length;
 
     await downloadGradioAudioFile(fileObj, destPath);
+
+    const lrcDestPath = path.join(AUDIO_DIR, `${jobId}_${sampleIndex}.lrc`);
+    const directLrcText = extractTextValue(data[36 + sampleIndex]).trim();
+    if (directLrcText && !directLrcText.startsWith('❌') && !directLrcText.startsWith('⚠️')) {
+      await writeFile(lrcDestPath, directLrcText, 'utf-8');
+      console.log(`Job ${jobId}: Saved Gradio LRC display text to ${lrcDestPath}`);
+    } else if (Array.isArray(allFiles)) {
+      // Fallback: try to find and download matching LRC or VTT file from allFiles.
+      const baseAudioName = origName.replace(/\.[^/.]+$/, '');
+      const matchingLrcObj = allFiles.find((f: any) => {
+        if (!f || (!f.path && !f.url)) return false;
+        const name = (f.orig_name || f.path || '').toLowerCase();
+        return (name.endsWith('.lrc') || name.endsWith('.vtt')) && name.includes(baseAudioName.toLowerCase());
+      }) || (audioUrls.length === 0 ? allFiles.find((f: any) => {
+        if (!f || (!f.path && !f.url)) return false;
+        const name = (f.orig_name || f.path || '').toLowerCase();
+        return name.endsWith('.lrc') || name.endsWith('.vtt');
+      }) : null);
+      if (matchingLrcObj) {
+        try {
+          await downloadGradioAudioFile(matchingLrcObj, lrcDestPath);
+          console.log(`Job ${jobId}: Downloaded matching LRC/VTT file to ${lrcDestPath}`);
+        } catch (err) {
+          console.warn(`Job ${jobId}: Failed to download matching LRC/VTT file`, err);
+        }
+      }
+    }
+    
+
 
     if (audioUrls.length === 0) {
       actualDuration = getAudioDuration(destPath);
@@ -635,14 +752,33 @@ async function processGenerationViaGradio(
     bpm: metas.bpm || params.bpm,
     keyScale: metas.keyScale || params.keyScale,
     timeSignature: metas.timeSignature || params.timeSignature,
+    scores: scoreOutputs,
     status: 'succeeded',
   };
-  job.rawResponse = { genDetails, genStatus };
+  job.rawResponse = { genDetails, genStatus, scores: scoreOutputs };
   console.log(`Job ${jobId}: Completed via Gradio with ${audioUrls.length} audio files`);
 }
 
 function isAudioFile(name: string): boolean {
   return /\.(mp3|flac|wav|ogg|m4a)$/i.test(name);
+}
+
+function extractTextValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (typeof record.value === 'string') return record.value;
+  }
+  return '';
+}
+
+function extractGradioScoreOutputs(data: unknown[]): string[] {
+  const scores: string[] = [];
+  for (let i = 0; i < 8; i++) {
+    const text = extractTextValue(data[12 + i]).trim();
+    scores.push(text && text !== 'Done!' ? text : '');
+  }
+  return scores;
 }
 
 function parseGenerationDetails(details: string | undefined): {
@@ -692,7 +828,7 @@ async function processGenerationViaPython(
     const jobOutputDir = path.join(ACESTEP_DIR, 'output', jobId);
     await mkdir(jobOutputDir, { recursive: true });
 
-    const durationToSend = params.duration && params.duration > 0 ? params.duration : 60;
+    const durationToSend = params.duration && params.duration > 0 ? params.duration : -1;
     const args = [
       '--prompt', prompt,
       '--duration', String(durationToSend),
@@ -732,6 +868,8 @@ async function processGenerationViaPython(
     }
     if (params.instruction) args.push('--instruction', params.instruction);
     if (params.thinking) args.push('--thinking');
+    if (params.getLrc) args.push('--get-lrc');
+    if (params.getScores) args.push('--get-scores', '--score-scale', String(params.scoreScale ?? 0.5));
     if (params.lmTemperature !== undefined) args.push('--lm-temperature', String(params.lmTemperature));
     if (params.lmCfgScale !== undefined) args.push('--lm-cfg-scale', String(params.lmCfgScale));
     
@@ -745,6 +883,7 @@ async function processGenerationViaPython(
     if (params.lmNegativePrompt) args.push('--lm-negative-prompt', params.lmNegativePrompt);
     if (params.lmModel) args.push('--lm-model', params.lmModel);
     if (params.lmBackend) args.push('--lm-backend', params.lmBackend);
+    if (params.ditModel) args.push('--dit-model', params.ditModel);
 
     const useCot = (params.enhance ?? false) || (params.thinking ?? false);
     if (!useCot) {
@@ -759,7 +898,12 @@ async function processGenerationViaPython(
     if (params.useAdg) args.push('--use-adg');
     if (params.cfgIntervalStart !== undefined && params.cfgIntervalStart > 0) args.push('--cfg-interval-start', String(params.cfgIntervalStart));
     if (params.cfgIntervalEnd !== undefined && params.cfgIntervalEnd < 1.0) args.push('--cfg-interval-end', String(params.cfgIntervalEnd));
-
+    if (params.dcwEnabled === false) args.push('--no-dcw');
+    if (params.dcwMode) args.push('--dcw-mode', params.dcwMode);
+    if (params.dcwScaler !== undefined) args.push('--dcw-scaler', String(params.dcwScaler));
+    if (params.dcwHighScaler !== undefined) args.push('--dcw-high-scaler', String(params.dcwHighScaler));
+    if (params.dcwWavelet) args.push('--dcw-wavelet', params.dcwWavelet);
+    if (params.vaeModel) args.push('--vae-checkpoint', params.vaeModel);
     const result = await runPythonGeneration(args);
 
     if (!result.success) {
@@ -779,6 +923,24 @@ async function processGenerationViaPython(
 
       await mkdir(AUDIO_DIR, { recursive: true });
       await copyFile(srcPath, destPath);
+
+      // Copy matching LRC or VTT file if exists next to the source audio path
+      let srcLrcPath = srcPath.replace(/\.[^/.]+$/, '.lrc');
+      if (!existsSync(srcLrcPath)) {
+        const srcVttPath = srcPath.replace(/\.[^/.]+$/, '.vtt');
+        if (existsSync(srcVttPath)) {
+          srcLrcPath = srcVttPath;
+        }
+      }
+      if (existsSync(srcLrcPath)) {
+        const lrcDestPath = path.join(AUDIO_DIR, `${jobId}_${audioUrls.length}.lrc`);
+        try {
+          await copyFile(srcLrcPath, lrcDestPath);
+           console.log(`Job ${jobId}: Copied matching LRC/VTT file from ${srcLrcPath} to ${lrcDestPath}`);
+        } catch (err) {
+           console.warn(`Job ${jobId}: Failed to copy matching LRC/VTT file`, err);
+        }
+      }
 
       if (audioUrls.length === 0) {
         actualDuration = getAudioDuration(destPath);
@@ -802,6 +964,7 @@ async function processGenerationViaPython(
       bpm: params.bpm,
       keyScale: params.keyScale,
       timeSignature: params.timeSignature,
+      scores: result.scores,
       status: 'succeeded',
     };
     job.rawResponse = result;
@@ -822,6 +985,7 @@ async function processGenerationViaPython(
 interface PythonResult {
   success: boolean;
   audio_paths?: string[];
+  scores?: string[];
   elapsed_seconds?: number;
   error?: string;
 }
@@ -830,6 +994,8 @@ function runPythonGeneration(scriptArgs: string[], timeoutMs = 600000): Promise<
   return new Promise((resolve) => {
     const pythonPath = resolvePythonPath(ACESTEP_DIR);
     const args = [PYTHON_SCRIPT, ...scriptArgs];
+
+    console.log(`[ACE-Step] [Spawn] Spawning Python command: "${pythonPath}" ${args.map(a => a.includes(' ') ? `"${a}"` : a).join(' ')}`);
 
     const proc = spawn(pythonPath, args, {
       cwd: ACESTEP_DIR,

--- a/services/api.ts
+++ b/services/api.ts
@@ -308,6 +308,12 @@ export interface GenerationParams {
   completeTrackClasses?: string[];
   isFormatCaption?: boolean;
   loraLoaded?: boolean;
+  dcwEnabled?: boolean;
+  dcwMode?: string;
+  dcwScaler?: number;
+  dcwHighScaler?: number;
+  dcwWavelet?: string;
+  vaeModel?: string;
 }
 
 export interface GenerationJob {

--- a/types.ts
+++ b/types.ts
@@ -120,6 +120,12 @@ export interface GenerationParams {
   trackName?: string;
   completeTrackClasses?: string[];
   isFormatCaption?: boolean;
+  dcwEnabled?: boolean;
+  dcwMode?: string;
+  dcwScaler?: number;
+  dcwHighScaler?: number;
+  dcwWavelet?: string;
+  vaeModel?: string;
 }
 
 export interface PlayerState {


### PR DESCRIPTION
## Summary
This PR introduces interactive synchronized lyrics playback with click-to-seek, improves visual/UX consistency (syncing player song changes with the detail sidebar), enables offline Python fallback scoring parity, and adds a VRAM-aware advisory guide for model selection.

---

## Key Changes

### 🎵 Frontend & Interactive Lyrics
* **Click-to-Seek Synchronized Lyrics**: 
  * Added an interactive lyric panel in `SongProfile.tsx` that highlights the active line dynamically.
  * Clicking on any lyric line jumps the playback directly to that specific timestamp (`onPlayAtTime`).
* **Active Song Detail Sync**: Fixed an issue where switching active songs in the player did not synchronize the right sidebar's active song details.
* **VRAM Advisory System**: Detects local GPU memory (VRAM) and provides advisory warning hints on `CreatePanel.tsx` to help users select appropriate LM sizes.
* **Visualizer Color Preset Generator**: Added custom color preset randomization logic (`randomizeColorPresets`) using HSL hue-distance calculation for beautiful visualizer options.
* **Model Selection Alignment**: Cleaned up layout positions for DCW settings and aligned DiT model tagging labels.

### 🛠️ Backend & Scoring Fallback
* **Fallback Scoring Engine**: Added `calculate_python_fallback_score` to `simple_generate.py` which calculates lyric alignment scores (LM & DiT Score) using cross-attention tensors and global PMI quality scores when running offline fallback.
* **LRC Export & Fallback Save**:
  * Added `--get-lrc`, `--get-scores`, and `--score-scale` CLI parameters to `simple_generate.py`.
  * Wired up automated download/saving of `.lrc`/`.vtt` timing files directly alongside downloaded audio outputs in `acestep.ts`.

---

## Verification
- Tested interactive lyrics scrolling and click-to-seek functionality in browser.
- Verified that switching songs updates the right-hand details pane in real-time.
- Verified fallback score calculation runs correctly when using the Python inference script locally.
- 
<img width="3982" height="1882" alt="image" src="https://github.com/user-attachments/assets/4ed107ed-c132-4bbe-a054-93710210afdb" />
<img width="1644" height="1240" alt="image" src="https://github.com/user-attachments/assets/1f8e1cd2-5510-4037-84f5-26bc46cdf935" />
