### PR TITLE
Add MiniMax music generation and cover support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,15 @@ DATABASE_PATH=./data/acestep.db
 # ACE-Step API (local)
 ACESTEP_API_URL=http://localhost:8001
 
+# MiniMax music generation (optional)
+# MUSIC_GENERATION_PROVIDER=minimax
+MINIMAX_API_KEY=
+MINIMAX_REGION=global_en
+MINIMAX_MUSIC_MODEL=music-3.0
+MINIMAX_MUSIC_STREAM=false
+MINIMAX_MUSIC_OUTPUT_FORMAT=url
+MINIMAX_MUSIC_AUDIO_FORMAT=mp3
+
 # Storage
 AUDIO_DIR=./public/audio
 

--- a/App.tsx
+++ b/App.tsx
@@ -803,6 +803,7 @@ function AppContent() {
         lyrics: params.lyrics,
         style: params.style,
         title: params.title,
+        ditModel: params.ditModel,
         instrumental: params.instrumental,
         vocalLanguage: params.vocalLanguage,
         duration: params.duration && params.duration > 0 ? params.duration : undefined,

--- a/server/.env.example
+++ b/server/.env.example
@@ -10,6 +10,15 @@ DATABASE_PATH=./data/acestep.db
 # ACE-Step API (local)
 ACESTEP_API_URL=http://localhost:8001
 
+# MiniMax music generation (optional)
+# MUSIC_GENERATION_PROVIDER=minimax
+MINIMAX_API_KEY=
+MINIMAX_REGION=global_en
+MINIMAX_MUSIC_MODEL=music-3.0
+MINIMAX_MUSIC_STREAM=false
+MINIMAX_MUSIC_OUTPUT_FORMAT=url
+MINIMAX_MUSIC_AUDIO_FORMAT=mp3
+
 # Storage
 AUDIO_DIR=./public/audio
 

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
+    "test": "tsx --test test/*.test.ts",
     "start": "node dist/index.js",
     "db:migrate": "tsx src/db/migrate.ts",
     "storage:test": "tsx src/scripts/test-storage.ts"

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -7,6 +7,17 @@ dotenv.config();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const musicProvider = process.env.MUSIC_GENERATION_PROVIDER?.toLowerCase() === 'minimax'
+  ? 'minimax' as const
+  : 'local' as const;
+const minimaxRegion = process.env.MINIMAX_REGION === 'cn_zh' ? 'cn_zh' as const : 'global_en' as const;
+const minimaxOutputFormat = process.env.MINIMAX_MUSIC_OUTPUT_FORMAT === 'hex' ? 'hex' as const : 'url' as const;
+const minimaxAudioFormat = process.env.MINIMAX_MUSIC_AUDIO_FORMAT === 'wav'
+  ? 'wav' as const
+  : process.env.MINIMAX_MUSIC_AUDIO_FORMAT === 'pcm'
+    ? 'pcm' as const
+    : 'mp3' as const;
+
 export const config = {
   port: parseInt(process.env.PORT || '3001', 10),
   nodeEnv: process.env.NODE_ENV || 'development',
@@ -19,6 +30,18 @@ export const config = {
   // ACE-Step API (local)
   acestep: {
     apiUrl: process.env.ACESTEP_API_URL || 'http://localhost:8001',
+  },
+
+  music: {
+    provider: musicProvider,
+    minimax: {
+      apiKey: process.env.MINIMAX_API_KEY || '',
+      region: minimaxRegion,
+      model: process.env.MINIMAX_MUSIC_MODEL || 'music-3.0',
+      stream: process.env.MINIMAX_MUSIC_STREAM === 'true',
+      outputFormat: minimaxOutputFormat,
+      audioFormat: minimaxAudioFormat,
+    },
   },
 
   // Pexels (optional - for video backgrounds)

--- a/server/src/routes/generate.ts
+++ b/server/src/routes/generate.ts
@@ -144,6 +144,9 @@ interface GenerateBody {
   musicBitrate?: 32000 | 64000 | 128000 | 256000;
   lyricsOptimizer?: boolean;
   aigcWatermark?: boolean;
+  sourceAudioBase64?: string;
+  sourceAudioDuration?: number;
+  coverFeatureId?: string;
   inferMethod?: 'ode' | 'sde';
   shift?: number;
 
@@ -272,6 +275,9 @@ router.post('/', authMiddleware, async (req: AuthenticatedRequest, res: Response
       musicBitrate,
       lyricsOptimizer,
       aigcWatermark,
+      sourceAudioBase64,
+      sourceAudioDuration,
+      coverFeatureId,
       inferMethod,
       shift,
       lmTemperature,
@@ -349,6 +355,9 @@ router.post('/', authMiddleware, async (req: AuthenticatedRequest, res: Response
       musicBitrate,
       lyricsOptimizer,
       aigcWatermark,
+      sourceAudioBase64,
+      sourceAudioDuration,
+      coverFeatureId,
       inferMethod,
       shift,
       lmTemperature,

--- a/server/src/routes/generate.ts
+++ b/server/src/routes/generate.ts
@@ -19,8 +19,34 @@ import {
   resolvePythonPath,
 } from '../services/acestep.js';
 import { getStorageProvider } from '../services/storage/factory.js';
+import { MINIMAX_MUSIC_MODELS, MINIMAX_PROVIDER_NAME } from '../services/minimax.js';
 
 const router = Router();
+
+type SupportedAudioFormat = 'mp3' | 'flac' | 'wav' | 'pcm';
+
+function resolveAudioFormat(audioUrl: string, fallback?: string): SupportedAudioFormat | null {
+  let pathname = audioUrl.toLowerCase();
+  try {
+    pathname = new URL(audioUrl, 'http://local').pathname.toLowerCase();
+  } catch {
+    // Use the raw value when it is not a URL.
+  }
+
+  for (const format of ['mp3', 'flac', 'wav', 'pcm'] as const) {
+    if (pathname.endsWith(`.${format}`)) return format;
+  }
+
+  return fallback && ['mp3', 'flac', 'wav', 'pcm'].includes(fallback)
+    ? fallback as SupportedAudioFormat
+    : null;
+}
+
+function audioContentType(format: SupportedAudioFormat): string {
+  if (format === 'mp3') return 'audio/mpeg';
+  if (format === 'pcm') return 'audio/L16';
+  return `audio/${format}`;
+}
 
 // Auto-generate a song title from lyrics or style when none is provided
 function autoTitle(params: { title?: string; lyrics?: string; instrumental?: boolean; style?: string; songDescription?: string }): string {
@@ -108,7 +134,16 @@ interface GenerateBody {
   randomSeed?: boolean;
   seed?: number;
   thinking?: boolean;
-  audioFormat?: 'mp3' | 'flac';
+  audioFormat?: 'mp3' | 'flac' | 'wav' | 'pcm';
+  musicModel?: string;
+  musicRegion?: 'global_en' | 'cn_zh';
+  stream?: boolean;
+  outputFormat?: 'url' | 'hex';
+  musicAudioFormat?: 'mp3' | 'wav' | 'pcm';
+  musicSampleRate?: 16000 | 24000 | 32000 | 44100;
+  musicBitrate?: 32000 | 64000 | 128000 | 256000;
+  lyricsOptimizer?: boolean;
+  aigcWatermark?: boolean;
   inferMethod?: 'ode' | 'sde';
   shift?: number;
 
@@ -228,6 +263,15 @@ router.post('/', authMiddleware, async (req: AuthenticatedRequest, res: Response
       seed,
       thinking,
       audioFormat,
+      musicModel,
+      musicRegion,
+      stream,
+      outputFormat,
+      musicAudioFormat,
+      musicSampleRate,
+      musicBitrate,
+      lyricsOptimizer,
+      aigcWatermark,
       inferMethod,
       shift,
       lmTemperature,
@@ -296,6 +340,15 @@ router.post('/', authMiddleware, async (req: AuthenticatedRequest, res: Response
       seed,
       thinking,
       audioFormat,
+      musicModel,
+      musicRegion,
+      stream,
+      outputFormat,
+      musicAudioFormat,
+      musicSampleRate,
+      musicBitrate,
+      lyricsOptimizer,
+      aigcWatermark,
       inferMethod,
       shift,
       lmTemperature,
@@ -411,10 +464,9 @@ router.get('/status/:jobId', authMiddleware, async (req: AuthenticatedRequest, r
           // If succeeded AND we were the first to update (optimistic lock), create song records
           if (aceStatus.status === 'succeeded' && aceStatus.result && wasUpdated) {
             const params = typeof job.params === 'string' ? JSON.parse(job.params) : job.params;
-            const audioUrls = aceStatus.result.audioUrls.filter((url: string) => {
-              const lower = url.toLowerCase();
-              return lower.endsWith('.mp3') || lower.endsWith('.flac') || lower.endsWith('.wav');
-            });
+            const audioUrls = aceStatus.result.audioUrls.filter((url: string) =>
+              resolveAudioFormat(url, aceStatus.result?.audioFormat) !== null
+            );
             const localPaths: string[] = [];
             const storage = getStorageProvider();
 
@@ -427,9 +479,10 @@ router.get('/status/:jobId', authMiddleware, async (req: AuthenticatedRequest, r
 
               try {
                 const { buffer } = await downloadAudioToBuffer(audioUrl);
-                const ext = audioUrl.includes('.flac') ? '.flac' : '.mp3';
+                const format = resolveAudioFormat(audioUrl, aceStatus.result.audioFormat) || 'mp3';
+                const ext = `.${format}`;
                 const storageKey = `${req.user!.id}/${songId}${ext}`;
-                await storage.upload(storageKey, buffer, `audio/${ext.slice(1)}`);
+                await storage.upload(storageKey, buffer, audioContentType(format));
                 const storedPath = storage.getPublicUrl(storageKey);
 
                 await pool.query(
@@ -598,6 +651,19 @@ router.get('/endpoints', authMiddleware, async (_req: AuthenticatedRequest, res:
 
 router.get('/models', async (_req, res: Response) => {
   try {
+    if (config.music.provider === 'minimax') {
+      const activeModel = config.music.minimax.model;
+      res.json({
+        provider: MINIMAX_PROVIDER_NAME,
+        models: MINIMAX_MUSIC_MODELS.map(name => ({
+          name,
+          is_active: name === activeModel,
+          is_preloaded: true,
+        })),
+      });
+      return;
+    }
+
     const ACESTEP_DIR = process.env.ACESTEP_PATH || path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../ACE-Step-1.5');
     const checkpointsDir = path.join(ACESTEP_DIR, 'checkpoints');
 

--- a/server/src/services/acestep.ts
+++ b/server/src/services/acestep.ts
@@ -1,4 +1,4 @@
-import { writeFile, mkdir, copyFile, rm, readFile } from 'fs/promises';
+import { writeFile, mkdir, copyFile, rm, readFile, stat } from 'fs/promises';
 import { spawn, execSync } from 'child_process';
 import { existsSync } from 'fs';
 import path from 'path';
@@ -23,6 +23,7 @@ import { config } from '../config/index.js';
 import { getGradioClient, resetGradioClient, isGradioAvailable } from './gradio-client.js';
 import {
   generateMusicWithMiniMax,
+  MINIMAX_MUSIC_COVER_MAX_BYTES,
   MINIMAX_MUSIC_ENDPOINTS,
   MINIMAX_MUSIC_MODELS,
   MINIMAX_PROVIDER_NAME,
@@ -294,6 +295,9 @@ export interface GenerationParams {
   musicBitrate?: 32000 | 64000 | 128000 | 256000;
   lyricsOptimizer?: boolean;
   aigcWatermark?: boolean;
+  sourceAudioBase64?: string;
+  sourceAudioDuration?: number;
+  coverFeatureId?: string;
   inferMethod?: 'ode' | 'sde';
   shift?: number;
 
@@ -551,7 +555,26 @@ async function processGenerationViaMiniMax(
 ): Promise<void> {
   job.stage = 'Generating music via MiniMax...';
 
-  const generated = await generateMusicWithMiniMax(params, config.music.minimax);
+  let providerParams = params;
+  const isCover = params.taskType === 'cover' || params.taskType === 'audio2audio';
+  if (isCover && params.sourceAudioUrl && !params.sourceAudioBase64) {
+    const sourcePath = resolveAudioPath(params.sourceAudioUrl);
+    if (sourcePath !== params.sourceAudioUrl || !/^https?:\/\//i.test(params.sourceAudioUrl)) {
+      const sourceStat = await stat(sourcePath);
+      if (sourceStat.size > MINIMAX_MUSIC_COVER_MAX_BYTES) {
+        throw new Error('MiniMax cover audio must not exceed 50 MB');
+      }
+      const sourceAudio = await readFile(sourcePath);
+      providerParams = {
+        ...params,
+        sourceAudioUrl: undefined,
+        sourceAudioBase64: sourceAudio.toString('base64'),
+        sourceAudioDuration: getAudioDuration(sourcePath) || params.sourceAudioDuration,
+      };
+    }
+  }
+
+  const generated = await generateMusicWithMiniMax(providerParams, config.music.minimax);
   let audioUrl: string;
 
   if (generated.outputFormat === 'url') {

--- a/server/src/services/acestep.ts
+++ b/server/src/services/acestep.ts
@@ -21,6 +21,12 @@ function getAudioDuration(filePath: string): number {
 import { fileURLToPath } from 'url';
 import { config } from '../config/index.js';
 import { getGradioClient, resetGradioClient, isGradioAvailable } from './gradio-client.js';
+import {
+  generateMusicWithMiniMax,
+  MINIMAX_MUSIC_ENDPOINTS,
+  MINIMAX_MUSIC_MODELS,
+  MINIMAX_PROVIDER_NAME,
+} from './minimax.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -278,7 +284,16 @@ export interface GenerationParams {
   seed?: number;
   thinking?: boolean;
   enhance?: boolean;
-  audioFormat?: 'mp3' | 'flac';
+  audioFormat?: 'mp3' | 'flac' | 'wav' | 'pcm';
+  musicModel?: string;
+  musicRegion?: 'global_en' | 'cn_zh';
+  stream?: boolean;
+  outputFormat?: 'url' | 'hex';
+  musicAudioFormat?: 'mp3' | 'wav' | 'pcm';
+  musicSampleRate?: 16000 | 24000 | 32000 | 44100;
+  musicBitrate?: 32000 | 64000 | 128000 | 256000;
+  lyricsOptimizer?: boolean;
+  aigcWatermark?: boolean;
   inferMethod?: 'ode' | 'sde';
   shift?: number;
 
@@ -327,6 +342,7 @@ export interface GenerationParams {
 interface GenerationResult {
   audioUrls: string[];
   duration: number;
+  audioFormat?: 'mp3' | 'flac' | 'wav' | 'pcm';
   bpm?: number;
   keyScale?: string;
   timeSignature?: string;
@@ -368,6 +384,9 @@ let isProcessingQueue = false;
 
 // Health check - verify Gradio app is reachable
 export async function checkSpaceHealth(): Promise<boolean> {
+  if (config.music.provider === 'minimax') {
+    return config.music.minimax.apiKey.trim().length > 0;
+  }
   return isGradioAvailable();
 }
 
@@ -407,6 +426,14 @@ async function switchModelIfNeeded(ditModel: string): Promise<void> {
 
 // Discover endpoints (for compatibility)
 export async function discoverEndpoints(): Promise<unknown> {
+  if (config.music.provider === 'minimax') {
+    return {
+      provider: MINIMAX_PROVIDER_NAME,
+      region: config.music.minimax.region,
+      endpoint: MINIMAX_MUSIC_ENDPOINTS[config.music.minimax.region],
+      models: MINIMAX_MUSIC_MODELS,
+    };
+  }
   return { provider: 'acestep-gradio', endpoint: ACESTEP_API };
 }
 
@@ -484,6 +511,16 @@ async function processGeneration(
   job.status = 'running';
   job.stage = 'Starting generation...';
 
+  if (config.music.provider === 'minimax') {
+    try {
+      await processGenerationViaMiniMax(jobId, params, job);
+    } catch (error) {
+      job.status = 'failed';
+      job.error = error instanceof Error ? error.message : 'MiniMax music generation failed';
+    }
+    return;
+  }
+
   // Guard: cover/audio2audio requires a source or audio codes
   if ((params.taskType === 'cover' || params.taskType === 'audio2audio') && !params.sourceAudioUrl && !params.audioCodes) {
     job.status = 'failed';
@@ -505,6 +542,44 @@ async function processGeneration(
 
   // Fallback: Python spawn
   await processGenerationViaPython(jobId, params, job);
+}
+
+async function processGenerationViaMiniMax(
+  jobId: string,
+  params: GenerationParams,
+  job: ActiveJob,
+): Promise<void> {
+  job.stage = 'Generating music via MiniMax...';
+
+  const generated = await generateMusicWithMiniMax(params, config.music.minimax);
+  let audioUrl: string;
+
+  if (generated.outputFormat === 'url') {
+    audioUrl = generated.audio;
+  } else {
+    await mkdir(AUDIO_DIR, { recursive: true });
+    const filename = `${jobId}_0.${generated.audioFormat}`;
+    const destination = path.join(AUDIO_DIR, filename);
+    const audioBuffer = Buffer.from(generated.audio, 'hex');
+    if (audioBuffer.length === 0) {
+      throw new Error('MiniMax music generation returned empty audio');
+    }
+    await writeFile(destination, audioBuffer);
+    audioUrl = `/audio/${filename}`;
+  }
+
+  job.status = 'succeeded';
+  job.result = {
+    audioUrls: [audioUrl],
+    duration: generated.duration ?? (params.duration && params.duration > 0 ? params.duration : 0),
+    audioFormat: generated.audioFormat,
+    bpm: params.bpm,
+    keyScale: params.keyScale,
+    timeSignature: params.timeSignature,
+    status: 'succeeded',
+  };
+  job.rawResponse = generated.rawResponse;
+  job.stage = 'Completed';
 }
 
 async function processGenerationViaGradio(
@@ -604,6 +679,7 @@ async function processGenerationViaGradio(
   job.result = {
     audioUrls,
     duration: finalDuration,
+    audioFormat,
     bpm: metas.bpm || params.bpm,
     keyScale: metas.keyScale || params.keyScale,
     timeSignature: metas.timeSignature || params.timeSignature,
@@ -614,7 +690,7 @@ async function processGenerationViaGradio(
 }
 
 function isAudioFile(name: string): boolean {
-  return /\.(mp3|flac|wav|ogg|m4a)$/i.test(name);
+  return /\.(mp3|flac|wav|pcm|ogg|m4a)$/i.test(name);
 }
 
 function parseGenerationDetails(details: string | undefined): {
@@ -756,6 +832,7 @@ async function processGenerationViaPython(
     job.result = {
       audioUrls,
       duration: finalDuration,
+      audioFormat: params.audioFormat ?? 'mp3',
       bpm: params.bpm,
       keyScale: params.keyScale,
       timeSignature: params.timeSignature,
@@ -916,7 +993,13 @@ export async function getAudioStream(audioPath: string): Promise<Response> {
     const localPath = path.join(AUDIO_DIR, audioPath.replace('/audio/', ''));
     try {
       const buffer = await readFile(localPath);
-      const ext = localPath.endsWith('.flac') ? 'flac' : 'mpeg';
+      const ext = localPath.endsWith('.flac')
+        ? 'flac'
+        : localPath.endsWith('.wav')
+          ? 'wav'
+          : localPath.endsWith('.pcm')
+            ? 'L16'
+            : 'mpeg';
       return new Response(buffer, {
         status: 200,
         headers: { 'Content-Type': `audio/${ext}` }
@@ -955,7 +1038,14 @@ export async function downloadAudio(remoteUrl: string, songId: string): Promise<
   }
 
   const buffer = await response.arrayBuffer();
-  const ext = remoteUrl.includes('.flac') ? '.flac' : '.mp3';
+  const pathname = (() => {
+    try {
+      return new URL(remoteUrl, 'http://local').pathname.toLowerCase();
+    } catch {
+      return remoteUrl.toLowerCase();
+    }
+  })();
+  const ext = ['.flac', '.wav', '.pcm'].find(value => pathname.endsWith(value)) || '.mp3';
   const filename = `${songId}${ext}`;
   const filepath = path.join(AUDIO_DIR, filename);
 

--- a/server/src/services/minimax.ts
+++ b/server/src/services/minimax.ts
@@ -1,0 +1,337 @@
+export const MINIMAX_PROVIDER_NAME = 'MiniMax';
+
+export const MINIMAX_MUSIC_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/music_generation',
+  cn_zh: 'https://api.minimaxi.com/v1/music_generation',
+} as const;
+
+export const MINIMAX_MUSIC_MODELS = [
+  'music-3.0',
+  'music-2.6',
+  'music-3.0-free',
+  'music-2.6-free',
+] as const;
+
+export const MINIMAX_MUSIC_OUTPUT_FORMATS = ['url', 'hex'] as const;
+export const MINIMAX_MUSIC_AUDIO_FORMATS = ['mp3', 'wav', 'pcm'] as const;
+export const MINIMAX_MUSIC_SAMPLE_RATES = [16000, 24000, 32000, 44100] as const;
+export const MINIMAX_MUSIC_BITRATES = [32000, 64000, 128000, 256000] as const;
+
+export type MiniMaxMusicRegion = keyof typeof MINIMAX_MUSIC_ENDPOINTS;
+export type MiniMaxMusicModel = typeof MINIMAX_MUSIC_MODELS[number];
+export type MiniMaxMusicOutputFormat = typeof MINIMAX_MUSIC_OUTPUT_FORMATS[number];
+export type MiniMaxMusicAudioFormat = typeof MINIMAX_MUSIC_AUDIO_FORMATS[number];
+export type MiniMaxMusicSampleRate = typeof MINIMAX_MUSIC_SAMPLE_RATES[number];
+export type MiniMaxMusicBitrate = typeof MINIMAX_MUSIC_BITRATES[number];
+
+export interface MiniMaxMusicClientConfig {
+  apiKey: string;
+  region: MiniMaxMusicRegion;
+  model: string;
+  stream: boolean;
+  outputFormat: MiniMaxMusicOutputFormat;
+  audioFormat: MiniMaxMusicAudioFormat;
+}
+
+export interface MiniMaxMusicGenerationParams {
+  customMode: boolean;
+  songDescription?: string;
+  lyrics?: string;
+  style?: string;
+  instrumental: boolean;
+  ditModel?: string;
+  musicModel?: string;
+  musicRegion?: MiniMaxMusicRegion;
+  stream?: boolean;
+  outputFormat?: MiniMaxMusicOutputFormat;
+  musicAudioFormat?: MiniMaxMusicAudioFormat;
+  musicSampleRate?: MiniMaxMusicSampleRate;
+  musicBitrate?: MiniMaxMusicBitrate;
+  lyricsOptimizer?: boolean;
+  aigcWatermark?: boolean;
+  taskType?: string;
+}
+
+export interface MiniMaxMusicRequest {
+  model: MiniMaxMusicModel;
+  prompt?: string;
+  lyrics?: string;
+  stream: boolean;
+  output_format: MiniMaxMusicOutputFormat;
+  audio_setting: {
+    format: MiniMaxMusicAudioFormat;
+    sample_rate?: MiniMaxMusicSampleRate;
+    bitrate?: MiniMaxMusicBitrate;
+  };
+  lyrics_optimizer: boolean;
+  is_instrumental: boolean;
+  aigc_watermark?: boolean;
+}
+
+interface MiniMaxMusicApiResponse {
+  data?: {
+    status?: number;
+    audio?: string;
+  };
+  extra_info?: {
+    music_duration?: number;
+  };
+  base_resp?: {
+    status_code?: number;
+    status_msg?: string;
+  };
+}
+
+export interface MiniMaxMusicResult {
+  provider: typeof MINIMAX_PROVIDER_NAME;
+  endpoint: string;
+  region: MiniMaxMusicRegion;
+  model: MiniMaxMusicModel;
+  status: 2;
+  audio: string;
+  outputFormat: MiniMaxMusicOutputFormat;
+  audioFormat: MiniMaxMusicAudioFormat;
+  duration?: number;
+  rawResponse: unknown;
+}
+
+function includesValue(values: readonly string[], value: string): boolean {
+  return values.includes(value);
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error('MiniMax returned an invalid JSON response');
+  }
+}
+
+function parseStreamPayloads(text: string): unknown[] {
+  const payloads: unknown[] = [];
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.replace(/^data:\s*/, '').trim();
+    if (!line || line === '[DONE]') continue;
+
+    try {
+      payloads.push(JSON.parse(line));
+    } catch {
+      // Some gateways return one regular JSON document even when stream=true.
+    }
+  }
+
+  return payloads.length > 0 ? payloads : [parseJson(text)];
+}
+
+function validateHttpsUrl(value: string): void {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:') throw new Error();
+  } catch {
+    throw new Error('MiniMax returned an invalid audio URL');
+  }
+}
+
+export function buildMiniMaxMusicRequest(
+  params: MiniMaxMusicGenerationParams,
+  clientConfig: MiniMaxMusicClientConfig,
+): {
+  endpoint: string;
+  region: MiniMaxMusicRegion;
+  model: MiniMaxMusicModel;
+  outputFormat: MiniMaxMusicOutputFormat;
+  audioFormat: MiniMaxMusicAudioFormat;
+  request: MiniMaxMusicRequest;
+} {
+  if (params.taskType && params.taskType !== 'text2music') {
+    throw new Error('MiniMax music generation only supports text-based generation');
+  }
+
+  const region = params.musicRegion ?? clientConfig.region;
+  const endpoint = MINIMAX_MUSIC_ENDPOINTS[region];
+  if (!endpoint) {
+    throw new Error(`Unsupported MiniMax region: ${region}`);
+  }
+
+  const requestedModel = params.musicModel ?? params.ditModel ?? clientConfig.model;
+  if (!includesValue(MINIMAX_MUSIC_MODELS, requestedModel)) {
+    throw new Error(`Unsupported MiniMax music model: ${requestedModel}`);
+  }
+  const model = requestedModel as MiniMaxMusicModel;
+
+  const stream = params.stream ?? clientConfig.stream;
+  const outputFormat = params.outputFormat ?? (stream ? 'hex' : clientConfig.outputFormat);
+  if (!includesValue(MINIMAX_MUSIC_OUTPUT_FORMATS, outputFormat)) {
+    throw new Error(`Unsupported MiniMax output format: ${outputFormat}`);
+  }
+  if (stream && outputFormat !== 'hex') {
+    throw new Error('MiniMax streaming music generation requires hex output');
+  }
+
+  const audioFormat = params.musicAudioFormat ?? clientConfig.audioFormat;
+  if (!includesValue(MINIMAX_MUSIC_AUDIO_FORMATS, audioFormat)) {
+    throw new Error(`Unsupported MiniMax audio format: ${audioFormat}`);
+  }
+  if (params.musicSampleRate !== undefined && !MINIMAX_MUSIC_SAMPLE_RATES.includes(params.musicSampleRate)) {
+    throw new Error(`Unsupported MiniMax sample rate: ${params.musicSampleRate}`);
+  }
+  if (params.musicBitrate !== undefined && !MINIMAX_MUSIC_BITRATES.includes(params.musicBitrate)) {
+    throw new Error(`Unsupported MiniMax bitrate: ${params.musicBitrate}`);
+  }
+
+  const prompt = (params.customMode ? (params.style || '') : (params.songDescription || params.style || '')).trim();
+  const lyrics = params.instrumental ? '' : (params.lyrics || '').trim();
+  const lyricsOptimizer = params.lyricsOptimizer ?? (!params.instrumental && lyrics.length === 0);
+
+  if (!prompt && !lyrics) {
+    throw new Error('MiniMax music generation requires a prompt or lyrics');
+  }
+  if (params.instrumental && !prompt) {
+    throw new Error('MiniMax instrumental generation requires a prompt');
+  }
+  if (!params.instrumental && !lyrics && !lyricsOptimizer) {
+    throw new Error('MiniMax vocal generation requires lyrics or lyrics optimization');
+  }
+
+  const request: MiniMaxMusicRequest = {
+    model,
+    stream,
+    output_format: outputFormat,
+    audio_setting: { format: audioFormat },
+    lyrics_optimizer: lyricsOptimizer,
+    is_instrumental: params.instrumental,
+  };
+
+  if (params.musicSampleRate !== undefined) {
+    request.audio_setting.sample_rate = params.musicSampleRate;
+  }
+  if (params.musicBitrate !== undefined) {
+    request.audio_setting.bitrate = params.musicBitrate;
+  }
+
+  if (prompt) request.prompt = prompt;
+  if (lyrics) request.lyrics = lyrics;
+  if (region === 'cn_zh' && params.aigcWatermark !== undefined) {
+    request.aigc_watermark = params.aigcWatermark;
+  }
+
+  return { endpoint, region, model, outputFormat, audioFormat, request };
+}
+
+export function parseMiniMaxMusicResponse(
+  payloads: unknown[],
+  outputFormat: MiniMaxMusicOutputFormat,
+): { status: 2; audio: string; duration?: number; rawResponse: unknown } {
+  let audio = '';
+  let status: number | undefined;
+  let duration: number | undefined;
+  let lastPayload: MiniMaxMusicApiResponse | undefined;
+  let sawSuccessCode = false;
+
+  for (const value of payloads) {
+    if (!value || typeof value !== 'object') {
+      throw new Error('MiniMax returned an invalid music response');
+    }
+
+    const payload = value as MiniMaxMusicApiResponse;
+    const statusCode = payload.base_resp?.status_code;
+    if (statusCode !== undefined) {
+      if (statusCode !== 0) {
+        const message = payload.base_resp?.status_msg || 'Music generation failed';
+        throw new Error(`MiniMax music generation failed (${statusCode}): ${message}`);
+      }
+      sawSuccessCode = true;
+    }
+
+    if (typeof payload.data?.status === 'number') {
+      status = payload.data.status;
+    }
+    if (typeof payload.data?.audio === 'string' && payload.data.audio.length > 0) {
+      audio = outputFormat === 'hex' ? audio + payload.data.audio : payload.data.audio;
+    }
+    if (typeof payload.extra_info?.music_duration === 'number') {
+      duration = payload.extra_info.music_duration / 1000;
+    }
+    lastPayload = payload;
+  }
+
+  if (!sawSuccessCode) {
+    throw new Error('MiniMax response did not include a success code');
+  }
+  if (status !== 2) {
+    throw new Error(`MiniMax music generation did not complete (status ${status ?? 'unknown'})`);
+  }
+  if (!audio) {
+    throw new Error('MiniMax music generation returned no audio');
+  }
+
+  if (outputFormat === 'hex') {
+    if (audio.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(audio)) {
+      throw new Error('MiniMax returned invalid hexadecimal audio');
+    }
+  } else {
+    validateHttpsUrl(audio);
+  }
+
+  return {
+    status: 2,
+    audio,
+    duration,
+    rawResponse: {
+      data: {
+        status,
+        ...(outputFormat === 'url' ? { audio } : {}),
+      },
+      extra_info: lastPayload?.extra_info,
+      base_resp: lastPayload?.base_resp,
+    },
+  };
+}
+
+export async function generateMusicWithMiniMax(
+  params: MiniMaxMusicGenerationParams,
+  clientConfig: MiniMaxMusicClientConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<MiniMaxMusicResult> {
+  if (!clientConfig.apiKey.trim()) {
+    throw new Error('MINIMAX_API_KEY is required for MiniMax music generation');
+  }
+
+  const built = buildMiniMaxMusicRequest(params, clientConfig);
+  const response = await fetchImpl(built.endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${clientConfig.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(built.request),
+  });
+  const responseText = await response.text();
+
+  if (!response.ok) {
+    let detail = response.statusText || 'Request failed';
+    try {
+      const payload = JSON.parse(responseText) as MiniMaxMusicApiResponse;
+      detail = payload.base_resp?.status_msg || detail;
+    } catch {
+      // Keep the HTTP status text when the body is not JSON.
+    }
+    throw new Error(`MiniMax music request failed (${response.status}): ${detail}`);
+  }
+
+  const payloads = built.request.stream
+    ? parseStreamPayloads(responseText)
+    : [parseJson(responseText)];
+  const parsed = parseMiniMaxMusicResponse(payloads, built.outputFormat);
+
+  return {
+    provider: MINIMAX_PROVIDER_NAME,
+    endpoint: built.endpoint,
+    region: built.region,
+    model: built.model,
+    outputFormat: built.outputFormat,
+    audioFormat: built.audioFormat,
+    ...parsed,
+  };
+}

--- a/server/src/services/minimax.ts
+++ b/server/src/services/minimax.ts
@@ -5,17 +5,30 @@ export const MINIMAX_MUSIC_ENDPOINTS = {
   cn_zh: 'https://api.minimaxi.com/v1/music_generation',
 } as const;
 
-export const MINIMAX_MUSIC_MODELS = [
+export const MINIMAX_MUSIC_GENERATION_MODELS = [
   'music-3.0',
   'music-2.6',
   'music-3.0-free',
   'music-2.6-free',
 ] as const;
 
+export const MINIMAX_MUSIC_COVER_MODELS = [
+  'music-cover',
+  'music-cover-free',
+] as const;
+
+export const MINIMAX_MUSIC_MODELS = [
+  ...MINIMAX_MUSIC_GENERATION_MODELS,
+  ...MINIMAX_MUSIC_COVER_MODELS,
+] as const;
+
 export const MINIMAX_MUSIC_OUTPUT_FORMATS = ['url', 'hex'] as const;
 export const MINIMAX_MUSIC_AUDIO_FORMATS = ['mp3', 'wav', 'pcm'] as const;
 export const MINIMAX_MUSIC_SAMPLE_RATES = [16000, 24000, 32000, 44100] as const;
 export const MINIMAX_MUSIC_BITRATES = [32000, 64000, 128000, 256000] as const;
+export const MINIMAX_MUSIC_COVER_MIN_SECONDS = 6;
+export const MINIMAX_MUSIC_COVER_MAX_SECONDS = 360;
+export const MINIMAX_MUSIC_COVER_MAX_BYTES = 50 * 1024 * 1024;
 
 export type MiniMaxMusicRegion = keyof typeof MINIMAX_MUSIC_ENDPOINTS;
 export type MiniMaxMusicModel = typeof MINIMAX_MUSIC_MODELS[number];
@@ -50,6 +63,10 @@ export interface MiniMaxMusicGenerationParams {
   lyricsOptimizer?: boolean;
   aigcWatermark?: boolean;
   taskType?: string;
+  sourceAudioUrl?: string;
+  sourceAudioBase64?: string;
+  sourceAudioDuration?: number;
+  coverFeatureId?: string;
 }
 
 export interface MiniMaxMusicRequest {
@@ -65,6 +82,9 @@ export interface MiniMaxMusicRequest {
   };
   lyrics_optimizer: boolean;
   is_instrumental: boolean;
+  audio_url?: string;
+  audio_base64?: string;
+  cover_feature_id?: string;
   aigc_watermark?: boolean;
 }
 
@@ -133,6 +153,28 @@ function validateHttpsUrl(value: string): void {
   }
 }
 
+function normalizeAudioBase64(value: string): string {
+  const normalized = value.replace(/^data:audio\/[a-z0-9.+-]+;base64,/i, '').trim();
+  if (!normalized || !/^[a-z0-9+/]+={0,2}$/i.test(normalized) || normalized.length % 4 !== 0) {
+    throw new Error('MiniMax cover generation requires valid base64 audio');
+  }
+  if (Buffer.byteLength(normalized, 'base64') > MINIMAX_MUSIC_COVER_MAX_BYTES) {
+    throw new Error('MiniMax cover audio must not exceed 50 MB');
+  }
+  return normalized;
+}
+
+function validateCoverDuration(duration: number | undefined): void {
+  if (duration === undefined) return;
+  if (
+    !Number.isFinite(duration)
+    || duration < MINIMAX_MUSIC_COVER_MIN_SECONDS
+    || duration > MINIMAX_MUSIC_COVER_MAX_SECONDS
+  ) {
+    throw new Error('MiniMax cover audio duration must be between 6 and 360 seconds');
+  }
+}
+
 export function buildMiniMaxMusicRequest(
   params: MiniMaxMusicGenerationParams,
   clientConfig: MiniMaxMusicClientConfig,
@@ -144,8 +186,9 @@ export function buildMiniMaxMusicRequest(
   audioFormat: MiniMaxMusicAudioFormat;
   request: MiniMaxMusicRequest;
 } {
-  if (params.taskType && params.taskType !== 'text2music') {
-    throw new Error('MiniMax music generation only supports text-based generation');
+  const isCover = params.taskType === 'cover' || params.taskType === 'audio2audio';
+  if (params.taskType && params.taskType !== 'text2music' && !isCover) {
+    throw new Error(`Unsupported MiniMax music task type: ${params.taskType}`);
   }
 
   const region = params.musicRegion ?? clientConfig.region;
@@ -154,8 +197,13 @@ export function buildMiniMaxMusicRequest(
     throw new Error(`Unsupported MiniMax region: ${region}`);
   }
 
-  const requestedModel = params.musicModel ?? params.ditModel ?? clientConfig.model;
-  if (!includesValue(MINIMAX_MUSIC_MODELS, requestedModel)) {
+  const configuredCoverModel = includesValue(MINIMAX_MUSIC_COVER_MODELS, clientConfig.model)
+    ? clientConfig.model
+    : MINIMAX_MUSIC_COVER_MODELS[0];
+  const requestedModel = params.musicModel
+    ?? (isCover ? configuredCoverModel : params.ditModel ?? clientConfig.model);
+  const allowedModels = isCover ? MINIMAX_MUSIC_COVER_MODELS : MINIMAX_MUSIC_GENERATION_MODELS;
+  if (!includesValue(allowedModels, requestedModel)) {
     throw new Error(`Unsupported MiniMax music model: ${requestedModel}`);
   }
   const model = requestedModel as MiniMaxMusicModel;
@@ -184,13 +232,13 @@ export function buildMiniMaxMusicRequest(
   const lyrics = params.instrumental ? '' : (params.lyrics || '').trim();
   const lyricsOptimizer = params.lyricsOptimizer ?? (!params.instrumental && lyrics.length === 0);
 
-  if (!prompt && !lyrics) {
+  if (!isCover && !prompt && !lyrics) {
     throw new Error('MiniMax music generation requires a prompt or lyrics');
   }
-  if (params.instrumental && !prompt) {
+  if (!isCover && params.instrumental && !prompt) {
     throw new Error('MiniMax instrumental generation requires a prompt');
   }
-  if (!params.instrumental && !lyrics && !lyricsOptimizer) {
+  if (!isCover && !params.instrumental && !lyrics && !lyricsOptimizer) {
     throw new Error('MiniMax vocal generation requires lyrics or lyrics optimization');
   }
 
@@ -212,6 +260,17 @@ export function buildMiniMaxMusicRequest(
 
   if (prompt) request.prompt = prompt;
   if (lyrics) request.lyrics = lyrics;
+  if (isCover) {
+    const sourceAudioUrl = params.sourceAudioUrl?.trim() || '';
+    const sourceAudioBase64 = params.sourceAudioBase64?.trim() || '';
+    if (Boolean(sourceAudioUrl) === Boolean(sourceAudioBase64)) {
+      throw new Error('MiniMax cover generation requires exactly one audio URL or base64 audio input');
+    }
+    validateCoverDuration(params.sourceAudioDuration);
+    if (sourceAudioUrl) request.audio_url = sourceAudioUrl;
+    if (sourceAudioBase64) request.audio_base64 = normalizeAudioBase64(sourceAudioBase64);
+    if (params.coverFeatureId?.trim()) request.cover_feature_id = params.coverFeatureId.trim();
+  }
   if (region === 'cn_zh' && params.aigcWatermark !== undefined) {
     request.aigc_watermark = params.aigcWatermark;
   }

--- a/server/test/minimax.test.ts
+++ b/server/test/minimax.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   generateMusicWithMiniMax,
   MINIMAX_MUSIC_AUDIO_FORMATS,
+  MINIMAX_MUSIC_COVER_MODELS,
   MINIMAX_MUSIC_MODELS,
   MINIMAX_MUSIC_OUTPUT_FORMATS,
   type MiniMaxMusicClientConfig,
@@ -23,7 +24,10 @@ test('exposes the configured generation models and formats', () => {
     'music-2.6',
     'music-3.0-free',
     'music-2.6-free',
+    'music-cover',
+    'music-cover-free',
   ]);
+  assert.deepEqual([...MINIMAX_MUSIC_COVER_MODELS], ['music-cover', 'music-cover-free']);
   assert.deepEqual([...MINIMAX_MUSIC_OUTPUT_FORMATS], ['url', 'hex']);
   assert.deepEqual([...MINIMAX_MUSIC_AUDIO_FORMATS], ['mp3', 'wav', 'pcm']);
 });
@@ -150,4 +154,89 @@ test('accepts lyrics-only custom generation without a prompt', async () => {
 
   assert.equal(requestBody.prompt, undefined);
   assert.equal(requestBody.lyrics, '[Verse]\nWords without a style prompt');
+});
+
+test('maps a cover request with an audio URL and feature ID', async () => {
+  let requestBody: Record<string, unknown> = {};
+
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body));
+    return new Response(JSON.stringify({
+      data: { status: 2, audio: 'https://cdn.example.com/cover.mp3' },
+      base_resp: { status_code: 0 },
+    }), { status: 200 });
+  };
+
+  await generateMusicWithMiniMax({
+    customMode: true,
+    lyrics: '',
+    instrumental: false,
+    taskType: 'cover',
+    musicModel: 'music-cover-free',
+    sourceAudioUrl: 'https://cdn.example.com/source.mp3',
+    sourceAudioDuration: 180,
+    coverFeatureId: 'feature-1',
+  }, defaultConfig, fetchImpl);
+
+  assert.deepEqual(requestBody, {
+    model: 'music-cover-free',
+    stream: false,
+    output_format: 'url',
+    audio_setting: { format: 'mp3' },
+    lyrics_optimizer: true,
+    is_instrumental: false,
+    audio_url: 'https://cdn.example.com/source.mp3',
+    cover_feature_id: 'feature-1',
+  });
+});
+
+test('maps base64 audio to the default cover model', async () => {
+  let requestBody: Record<string, unknown> = {};
+
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body));
+    return new Response(JSON.stringify({
+      data: { status: 2, audio: 'https://cdn.example.com/cover.mp3' },
+      base_resp: { status_code: 0 },
+    }), { status: 200 });
+  };
+
+  await generateMusicWithMiniMax({
+    customMode: true,
+    lyrics: '',
+    instrumental: false,
+    taskType: 'audio2audio',
+    sourceAudioBase64: Buffer.from('audio').toString('base64'),
+    sourceAudioDuration: 6,
+  }, defaultConfig, fetchImpl);
+
+  assert.equal(requestBody.model, 'music-cover');
+  assert.equal(requestBody.audio_base64, 'YXVkaW8=');
+  assert.equal(requestBody.audio_url, undefined);
+});
+
+test('validates cover input selection and duration', async () => {
+  await assert.rejects(
+    generateMusicWithMiniMax({
+      customMode: true,
+      lyrics: '',
+      instrumental: false,
+      taskType: 'cover',
+      sourceAudioUrl: 'https://cdn.example.com/source.mp3',
+      sourceAudioBase64: Buffer.from('audio').toString('base64'),
+    }, defaultConfig),
+    /exactly one audio URL or base64 audio input/,
+  );
+
+  await assert.rejects(
+    generateMusicWithMiniMax({
+      customMode: true,
+      lyrics: '',
+      instrumental: false,
+      taskType: 'cover',
+      sourceAudioUrl: 'https://cdn.example.com/source.mp3',
+      sourceAudioDuration: 361,
+    }, defaultConfig),
+    /between 6 and 360 seconds/,
+  );
 });

--- a/server/test/minimax.test.ts
+++ b/server/test/minimax.test.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  generateMusicWithMiniMax,
+  MINIMAX_MUSIC_AUDIO_FORMATS,
+  MINIMAX_MUSIC_MODELS,
+  MINIMAX_MUSIC_OUTPUT_FORMATS,
+  type MiniMaxMusicClientConfig,
+} from '../src/services/minimax.js';
+
+const defaultConfig: MiniMaxMusicClientConfig = {
+  apiKey: 'test-key',
+  region: 'global_en',
+  model: 'music-3.0',
+  stream: false,
+  outputFormat: 'url',
+  audioFormat: 'mp3',
+};
+
+test('exposes the configured generation models and formats', () => {
+  assert.deepEqual([...MINIMAX_MUSIC_MODELS], [
+    'music-3.0',
+    'music-2.6',
+    'music-3.0-free',
+    'music-2.6-free',
+  ]);
+  assert.deepEqual([...MINIMAX_MUSIC_OUTPUT_FORMATS], ['url', 'hex']);
+  assert.deepEqual([...MINIMAX_MUSIC_AUDIO_FORMATS], ['mp3', 'wav', 'pcm']);
+});
+
+test('maps a global music request and parses URL output', async () => {
+  let requestedUrl = '';
+  let requestBody: Record<string, unknown> = {};
+  let authorization = '';
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    requestedUrl = String(input);
+    requestBody = JSON.parse(String(init?.body));
+    authorization = new Headers(init?.headers).get('Authorization') || '';
+    return new Response(JSON.stringify({
+      data: {
+        status: 2,
+        audio: 'https://cdn.example.com/generated.mp3',
+      },
+      extra_info: { music_duration: 12345 },
+      base_resp: { status_code: 0, status_msg: 'success' },
+    }), { status: 200 });
+  };
+
+  const result = await generateMusicWithMiniMax({
+    customMode: true,
+    style: 'cinematic synth music',
+    lyrics: '[Verse]\nA quiet signal',
+    instrumental: false,
+    musicModel: 'music-3.0',
+    outputFormat: 'url',
+    musicAudioFormat: 'mp3',
+    musicSampleRate: 44100,
+    musicBitrate: 256000,
+  }, defaultConfig, fetchImpl);
+
+  assert.equal(requestedUrl, 'https://api.minimax.io/v1/music_generation');
+  assert.equal(authorization, 'Bearer test-key');
+  assert.deepEqual(requestBody, {
+    model: 'music-3.0',
+    prompt: 'cinematic synth music',
+    lyrics: '[Verse]\nA quiet signal',
+    stream: false,
+    output_format: 'url',
+    audio_setting: { format: 'mp3', sample_rate: 44100, bitrate: 256000 },
+    lyrics_optimizer: false,
+    is_instrumental: false,
+  });
+  assert.equal(result.audio, 'https://cdn.example.com/generated.mp3');
+  assert.equal(result.duration, 12.345);
+});
+
+test('maps the China endpoint and combines streamed hexadecimal audio', async () => {
+  let requestBody: Record<string, unknown> = {};
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    assert.equal(String(input), 'https://api.minimaxi.com/v1/music_generation');
+    requestBody = JSON.parse(String(init?.body));
+    return new Response([
+      'data: {"data":{"status":1,"audio":"0011"},"base_resp":{"status_code":0}}',
+      '',
+      'data: {"data":{"status":2,"audio":"aabb"},"base_resp":{"status_code":0}}',
+      '',
+    ].join('\n'), { status: 200 });
+  };
+
+  const result = await generateMusicWithMiniMax({
+    customMode: false,
+    songDescription: 'instrumental piano',
+    instrumental: true,
+    musicModel: 'music-2.6',
+    musicRegion: 'cn_zh',
+    stream: true,
+    outputFormat: 'hex',
+    musicAudioFormat: 'wav',
+    aigcWatermark: true,
+  }, defaultConfig, fetchImpl);
+
+  assert.deepEqual(requestBody, {
+    model: 'music-2.6',
+    prompt: 'instrumental piano',
+    stream: true,
+    output_format: 'hex',
+    audio_setting: { format: 'wav' },
+    lyrics_optimizer: false,
+    is_instrumental: true,
+    aigc_watermark: true,
+  });
+  assert.equal(result.audio, '0011aabb');
+  assert.equal(result.audioFormat, 'wav');
+});
+
+test('requires hexadecimal output for streaming requests', async () => {
+  await assert.rejects(
+    generateMusicWithMiniMax({
+      customMode: false,
+      songDescription: 'ambient instrumental',
+      instrumental: true,
+      stream: true,
+      outputFormat: 'url',
+    }, defaultConfig),
+    /requires hex output/,
+  );
+});
+
+test('accepts lyrics-only custom generation without a prompt', async () => {
+  let requestBody: Record<string, unknown> = {};
+
+  const fetchImpl: typeof fetch = async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body));
+    return new Response(JSON.stringify({
+      data: {
+        status: 2,
+        audio: 'https://cdn.example.com/lyrics-only.mp3',
+      },
+      base_resp: { status_code: 0 },
+    }), { status: 200 });
+  };
+
+  await generateMusicWithMiniMax({
+    customMode: true,
+    lyrics: '[Verse]\nWords without a style prompt',
+    instrumental: false,
+  }, defaultConfig, fetchImpl);
+
+  assert.equal(requestBody.prompt, undefined);
+  assert.equal(requestBody.lyrics, '[Verse]\nWords without a style prompt');
+});


### PR DESCRIPTION
Reason: Add MiniMax music cover support to the current music generation integration.

## Changes

- Add region-aware music generation with the current models, request fields, output formats, and response parsing.
- Add the music cover models and map URL or base64 source audio plus optional cover feature IDs.
- Validate exclusive cover inputs, the 6–360 second source duration, and the 50 MB source size limit.
- Convert local cover audio to base64 while leaving remotely accessible audio as a URL.

## Checks

- `cd server && npm test -- --test-name-pattern='MiniMax|cover|music'`
- `cd server && npm run build`
- `git diff --check origin/main...HEAD`